### PR TITLE
fix: add skills path to plugin.json

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,8 +1,9 @@
 {
   "name": "stellar-dev",
   "description": "End-to-end Stellar development: Soroban smart contracts (Rust), stellar-sdk (JS/Python/Go), RPC/Horizon APIs, Stellar Assets, wallet integration, testing, security, and ecosystem",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": {
     "name": "Stellar Development Foundation"
-  }
+  },
+  "skills": "./skill/"
 }


### PR DESCRIPTION
Fixes #11

## Problem
`plugin.json` was missing the `skills` field. Claude Code defaults to looking for skills in `skills/` (plural), but this repo uses `skill/` (singular). As a result, the skill was silently not loaded after installation — confirmed by `/reload-plugins` showing `0 skills`.

## Fix
- Added `"skills": "./skill/"` to `.claude-plugin/plugin.json`
- Bumped version to `1.1.1`