### PR TITLE
Fix preview basePath to match pr-preview-action deploy path

### DIFF
--- a/.github/workflows/preview-pr.yml
+++ b/.github/workflows/preview-pr.yml
@@ -69,10 +69,13 @@ jobs:
         uses: actions/checkout@v4
 
       # Preview-scoped basePath. The site is served from skills.stellar.org
-      # at the apex, so previews live at `skills.stellar.org/pr/<N>/`.
+      # at the apex, so previews live at `skills.stellar.org/pr/pr-<N>/`.
+      # `rossjrw/pr-preview-action` deploys under `<umbrella-dir>/pr-<N>`
+      # by default, so the basePath must include the `pr-` prefix on the
+      # number to match — otherwise asset URLs baked into the HTML 404.
       - name: Resolve NEXT_BASE_PATH
         if: github.event.action != 'closed'
-        run: echo "NEXT_BASE_PATH=/pr/${{ github.event.number }}" >> "$GITHUB_ENV"
+        run: echo "NEXT_BASE_PATH=/pr/pr-${{ github.event.number }}" >> "$GITHUB_ENV"
 
       - if: github.event.action != 'closed'
         uses: pnpm/action-setup@v4


### PR DESCRIPTION
Closes #23.

`preview-pr.yml` was building Next.js with `NEXT_BASE_PATH=/pr/<N>` while `rossjrw/pr-preview-action` actually deploys under `/pr/pr-<N>/`  so asset URLs in the built HTML 404'd and previews rendered unstyled. Add the `pr-` prefix to the basePath so it matches the deploy path.

Production is unaffected (this workflow only runs on `pull_request`; `deploy-pages.yml` is independent).