### PR TITLE
fix: correct plugin install command + add Codex install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ These skills work with any agent that supports the [Agent Skills](https://agents
 /plugin marketplace add stellar/stellar-dev-skill
 
 # Then install the skill
-/plugin install stellar-dev@stellar-dev-skill
+/plugin install stellar-dev@stellar-dev
 ```
 
 ### [npx skills](https://skills.sh)

--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ These skills work with any agent that supports the [Agent Skills](https://agents
 /plugin install stellar-dev@stellar-dev
 ```
 
+### [OpenAI Codex](https://developers.openai.com/codex/skills/)
+
+```bash
+git clone https://github.com/stellar/stellar-dev-skill ~/.codex/skills/stellar-dev-skill
+```
+
 ### [npx skills](https://skills.sh)
 
 ```bash

--- a/site/src/data/installers.mjs
+++ b/site/src/data/installers.mjs
@@ -21,7 +21,7 @@ export const INSTALLERS = [
     description: "Install using the plugin marketplace:",
     commands: [
       "/plugin marketplace add stellar/stellar-dev-skill",
-      "/plugin install stellar-dev@stellar-dev-skill",
+      "/plugin install stellar-dev@stellar-dev",
     ],
   },
   {

--- a/site/src/data/installers.mjs
+++ b/site/src/data/installers.mjs
@@ -31,6 +31,13 @@ export const INSTALLERS = [
     commands: ["stellar/stellar-dev-skill"],
   },
   {
+    name: "OpenAI Codex",
+    description: "Clone the repo into your Codex skills directory:",
+    commands: [
+      "git clone https://github.com/stellar/stellar-dev-skill ~/.codex/skills/stellar-dev-skill",
+    ],
+  },
+  {
     name: "npx skills",
     description: "Install using the npx skills CLI:",
     commands: ["npx skills add https://github.com/stellar/stellar-dev-skill"],


### PR DESCRIPTION
## Summary
- Fix the Claude Code install command, which was failing because the marketplace name in `.claude-plugin/marketplace.json` is `stellar-dev`, not `stellar-dev-skill`. Updates README and the site installer card to `/plugin install stellar-dev@stellar-dev`.
- Add an OpenAI Codex install section (clone into `~/.codex/skills/`) to both the README and the landing-page installer cards.

## Repro of the install bug (closes #28)

```
> /plugin marketplace add stellar/stellar-dev-skill
  └ Successfully added marketplace: stellar-dev

> /plugin install stellar-dev@stellar-dev-skill
  └ Marketplace "stellar-dev-skill" not found
```

Reported by @iamjayrome on Twitter: https://x.com/iamjayrome/status/2057528609599111530

## Codex docs (part of #27)

Addresses one item from @jamesbachini's feedback in #27: surface a one-line Codex install command. Path uses `~/.codex/skills/` to match the existing Skill Directory table in the README.

## Test plan
- [ ] Run `/plugin marketplace add stellar/stellar-dev-skill` then `/plugin install stellar-dev@stellar-dev` in Claude Code and confirm install succeeds.
- [ ] Build the site and confirm the Installing card grid shows both the corrected Claude Code command and the new Codex card.
- [ ] Confirm `~/.codex/skills/stellar-dev-skill` clone is the right pattern for Codex skill discovery (or adjust path).