### PR TITLE
(feat) add Anchors to community skills

### DIFF
--- a/site/src/data/skills.ts
+++ b/site/src/data/skills.ts
@@ -173,7 +173,7 @@ export const ECOSYSTEM_CARDS: readonly EcosystemCardSource[] = [
   {
     title: "Anchors",
     description:
-      "Teach your AI coding agent how to integrate with and build Stellar anchors (fiat on/off-ramps).",
+      "Integrate with or build Stellar anchors — fiat on/off-ramps, deposit/withdrawal, KYC, RFQ, cross-border remittance. The implementation layer for SEPs 1/6/10/12/24/31/38: what to build, in what order, and the gotchas (memo contracts, trustline traps, state machine) that bite.",
     pathLabel: "CheesecakeLabs/stellar-anchor-skill",
     copyValue:
       "https://github.com/CheesecakeLabs/stellar-anchor-skill/blob/main/SKILL.md",

--- a/site/src/data/skills.ts
+++ b/site/src/data/skills.ts
@@ -173,7 +173,7 @@ export const ECOSYSTEM_CARDS: readonly EcosystemCardSource[] = [
   {
     title: "Anchors",
     description:
-      "Integrate with or build Stellar anchors — fiat on/off-ramps, deposit/withdrawal, KYC, RFQ, cross-border remittance. The implementation layer for SEPs 1/6/10/12/24/31/38: what to build, in what order, and the gotchas (memo contracts, trustline traps, state machine) that bite.",
+      "Integrate with or build Stellar anchors (fiat on/off-ramps, deposits/withdrawals, KYC). Covers core SEP flows (1/6/10/12/24/31/38) and common integration pitfalls.",
     pathLabel: "CheesecakeLabs/stellar-anchor-skill",
     copyValue:
       "https://github.com/CheesecakeLabs/stellar-anchor-skill/blob/main/SKILL.md",

--- a/site/src/data/skills.ts
+++ b/site/src/data/skills.ts
@@ -170,4 +170,13 @@ export const ECOSYSTEM_CARDS: readonly EcosystemCardSource[] = [
       "https://github.com/Trustless-Work/trustless-work-dev-skill/blob/main/SKILL.md",
     category: "Ecosystem",
   },
+  {
+    title: "Anchors",
+    description:
+      "Teach your AI coding agent how to integrate with and build Stellar anchors (fiat on/off-ramps).",
+    pathLabel: "CheesecakeLabs/stellar-anchor-skill",
+    copyValue:
+      "https://github.com/CheesecakeLabs/stellar-anchor-skill/blob/main/SKILL.md",
+    category: "Ecosystem",
+  },
 ] as const;


### PR DESCRIPTION
## Summary
Adds a community skill card for Anchors — an Agent Skill to integrate with and build Stellar anchors.

## What changed
- `site/src/data/skills.ts` — appended one entry to `ECOSYSTEM_CARDS`:
  - Title: Anchors
  - Category: Ecosystem
  - Links to `CheesecakeLabs/stellar-anchor-skill`

## Why
Anchors is an Agent Skill developed by Cheesecake Labs to integrate with and build Stellar anchors. Adding it here makes it discoverable to developers browsing skills.stellar.org.

## Test plan
- [x]   `pnpm lint:ts` passes
- [x]   `pnpm lint` passes
- [x]   `pnpm build` succeeds (produces out/)
- [x]   Anchors card visible in curl out/index.html (server-rendered)
- [x]   Copy button copies `https://github.com/CheesecakeLabs/stellar-anchor-skill/blob/main/SKILL.md`