### PR TITLE
Update dapp skill to JS SDK v16 (contract.Client, Node 22, pollTransaction)

### DIFF
--- a/skills/dapp/SKILL.md
+++ b/skills/dapp/SKILL.md
@@ -279,7 +279,8 @@ export async function buildPaymentTx(
 The canonical way to call a Soroban contract from JS is the `contract.Client`, not hand-built `Contract.call` + `assembleTransaction`. The client reads the contract's interface from the network, so each method is callable by name and returns an `AssembledTransaction`. You get a native JS result and don't build ScVals by hand.
 
 ```typescript
-import { contract, rpc, Networks } from "@stellar/stellar-sdk";
+import { contract } from "@stellar/stellar-sdk";
+import { config } from "@/lib/stellar";
 
 // Describe just the methods you call. `Client.from<T>()` uses this to type
 // the returned client, so calls are checked and autocompleted — no codegen.
@@ -301,8 +302,8 @@ export async function getCounterClient(
 ) {
   return contract.Client.from<CounterContract>({
     contractId,
-    rpcUrl: "https://soroban-testnet.stellar.org",
-    networkPassphrase: Networks.TESTNET,
+    rpcUrl: config.rpcUrl,
+    networkPassphrase: config.networkPassphrase,
     publicKey,
     signTransaction,
   });

--- a/skills/dapp/SKILL.md
+++ b/skills/dapp/SKILL.md
@@ -42,13 +42,15 @@ Client-side development with `@stellar/stellar-sdk`, wallet connection, signing,
 
 ## Recommended Dependencies
 
-> **Requires Node.js 20+** — the Stellar SDK dropped Node 18 support.
+> **Requires Node.js 22+.** As of SDK v16, Node 22 is the minimum (older Node produces an `EBADENGINE` warning). v16 also folded `@stellar/stellar-base` into `@stellar/stellar-sdk`, is ESM-first, and uses native `fetch` instead of axios. If you still import `@stellar/stellar-base` directly, switch the import to `@stellar/stellar-sdk` and uninstall the base package (keeping both breaks `instanceof` checks). See the [migration guide](https://stellar.github.io/js-stellar-sdk/guides/00-migration).
 
 ```bash
 npm install @stellar/stellar-sdk @stellar/freighter-api
 # Or for multi-wallet support:
 npm install @stellar/stellar-sdk @creit.tech/stellar-wallets-kit
 ```
+
+> **Sourcing:** SDK mechanics below (init, transaction building, contract invocation, submission, data fetching, error handling) track the official [JS SDK docs](https://stellar.github.io/js-stellar-sdk/) (which also publish [`llms.txt`](https://stellar.github.io/js-stellar-sdk/llms.txt) / [`llms-full.txt`](https://stellar.github.io/js-stellar-sdk/llms-full.txt) bundles for agents). Wallet integrations (Freighter, Stellar Wallets Kit), passkey smart accounts, and the OpenZeppelin relayer are separate packages, not part of the JS SDK — verify those against their own upstream docs.
 
 ## SDK Initialization
 
@@ -272,7 +274,56 @@ export async function buildPaymentTx(
 }
 ```
 
-### Smart Contract Invocation
+### Smart Contract Invocation (`contract.Client`)
+
+The canonical way to call a Soroban contract from JS is the `contract.Client`, not hand-built `Contract.call` + `assembleTransaction`. The client reads the contract's interface from the network, so each method is callable by name and returns an `AssembledTransaction`. You get a native JS result and don't build ScVals by hand.
+
+```typescript
+import { contract, rpc, Networks } from "@stellar/stellar-sdk";
+
+// Describe just the methods you call. `Client.from<T>()` uses this to type
+// the returned client, so calls are checked and autocompleted — no codegen.
+// For a contract with many methods, generate this interface from its spec
+// with the SDK's binding CLI instead of writing it by hand.
+interface CounterContract {
+  increment: (
+    options?: contract.MethodOptions,
+  ) => Promise<contract.AssembledTransaction<number>>;
+}
+
+// `signTransaction` comes from the wallet (e.g. Freighter/Wallets Kit in the
+// browser). `contract.basicNodeSigner(keypair, networkPassphrase)` is the
+// Node equivalent for scripts and tests.
+export async function getCounterClient(
+  contractId: string,
+  publicKey: string,
+  signTransaction: contract.ClientOptions["signTransaction"],
+) {
+  return contract.Client.from<CounterContract>({
+    contractId,
+    rpcUrl: "https://soroban-testnet.stellar.org",
+    networkPassphrase: Networks.TESTNET,
+    publicKey,
+    signTransaction,
+  });
+}
+
+// Preview (free simulation) then sign + send to apply on-chain.
+export async function increment(client: contract.Client & CounterContract) {
+  const tx = await client.increment();
+  console.log("preview:", tx.result); // predicted return value, no signature
+  const sent = await tx.signAndSend(); // submits and polls to completion
+  return sent.result;
+}
+```
+
+`AssembledTransaction` also supports fine-grained control (`{ fee, simulate, timeoutInSeconds }` as a second arg) and multi-party auth via `tx.needsNonInvokerSigningBy()` / `tx.signAuthEntries()`. See [Invoke a Contract](https://stellar.github.io/js-stellar-sdk/guides/06-invoke-a-contract) and [Authorize a Contract Call](https://stellar.github.io/js-stellar-sdk/guides/07-contract-auth).
+
+<details>
+<summary><b>Advanced: low-level invocation without a client</b></summary>
+
+Use this only when you need direct control over the transaction (e.g. batching a contract call with classic operations). Otherwise prefer `contract.Client` above.
+
 ```typescript
 import * as StellarSdk from "@stellar/stellar-sdk";
 import { rpc, config } from "@/lib/stellar";
@@ -284,10 +335,9 @@ export async function invokeContract(
   args: StellarSdk.xdr.ScVal[]
 ) {
   const account = await rpc.getAccount(sourceAddress);
-
   const contract = new StellarSdk.Contract(contractId);
 
-  let transaction = new StellarSdk.TransactionBuilder(account, {
+  const transaction = new StellarSdk.TransactionBuilder(account, {
     fee: StellarSdk.BASE_FEE,
     networkPassphrase: config.networkPassphrase,
   })
@@ -295,28 +345,18 @@ export async function invokeContract(
     .setTimeout(180)
     .build();
 
-  // Simulate to get resource estimates
-  const simulation = await rpc.simulateTransaction(transaction);
-
-  if (StellarSdk.rpc.Api.isSimulationError(simulation)) {
-    throw new Error(`Simulation failed: ${simulation.error}`);
-  }
-
-  // Assemble with proper resources
-  transaction = StellarSdk.rpc.assembleTransaction(
-    transaction,
-    simulation
-  ).build();
-
-  return transaction.toXDR();
+  // `prepareTransaction` simulates and applies footprint/auth/fees in one step.
+  // (Equivalent to simulateTransaction + rpc.assembleTransaction.)
+  const prepared = await rpc.prepareTransaction(transaction);
+  return prepared.toXDR();
 }
 ```
 
-### Building ScVal Arguments
+**Building ScVal arguments by hand** (only needed for the low-level path — `contract.Client` converts native JS args for you):
+
 ```typescript
 import * as StellarSdk from "@stellar/stellar-sdk";
 
-// Common conversions
 const addressVal = StellarSdk.Address.fromString(address).toScVal();
 const i128Val = StellarSdk.nativeToScVal(BigInt(amount), { type: "i128" });
 const u32Val = StellarSdk.nativeToScVal(42, { type: "u32" });
@@ -334,9 +374,14 @@ const structVal = StellarSdk.nativeToScVal(
   }
 );
 
-// Vec
-const vecVal = StellarSdk.nativeToScVal([1, 2, 3], { type: "i128" });
+// Vec of i128 — the element type is applied to each item
+const vecVal = StellarSdk.nativeToScVal(
+  [1, 2, 3].map((n) => BigInt(n)),
+  { type: "i128" }
+);
 ```
+
+</details>
 
 ## Transaction Submission
 
@@ -369,15 +414,13 @@ async function submitSorobanTransaction(signedXdr: string) {
   const response = await rpc.sendTransaction(transaction);
 
   if (response.status === "ERROR") {
-    throw new Error(`Transaction failed: ${response.errorResult}`);
+    throw new Error(`Send failed: ${response.errorResult}`);
   }
 
-  // Poll for completion
-  let getResponse = await rpc.getTransaction(response.hash);
-  while (getResponse.status === "NOT_FOUND") {
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-    getResponse = await rpc.getTransaction(response.hash);
-  }
+  // Poll for completion. pollTransaction handles the retry loop (default 5
+  // attempts, 1s apart — tune with { attempts, sleepStrategy }) instead of a
+  // hand-rolled while loop that can spin forever.
+  const getResponse = await rpc.pollTransaction(response.hash);
 
   if (getResponse.status === "SUCCESS") {
     return {
@@ -551,6 +594,7 @@ export default function RootLayout({
 
 ### Account Balance
 ```typescript
+import { NotFoundError } from "@stellar/stellar-sdk";
 import { horizon } from "@/lib/stellar";
 
 export async function getBalance(address: string) {
@@ -561,15 +605,43 @@ export async function getBalance(address: string) {
     );
     return nativeBalance?.balance || "0";
   } catch (error) {
-    if (error.response?.status === 404) {
-      return "0"; // Account not funded
+    // loadAccount rejects with the typed NotFoundError for an unfunded account.
+    if (error instanceof NotFoundError) {
+      return "0"; // Account not funded yet
     }
     throw error;
   }
 }
 ```
 
+> For submission failures, Horizon returns result codes under `error.response?.data?.extras?.result_codes` (`transaction` + per-`operation`). See [Handle Errors](https://stellar.github.io/js-stellar-sdk/guides/05-handle-errors).
+
 ### Contract State
+
+For a read-only contract call, `rpc.Server` has one-line shortcuts that build the contract interface for you (including the built-in spec for Stellar Asset Contracts), so no client setup or manual ScVal work is needed:
+
+```typescript
+import { rpc } from "@/lib/stellar";
+
+// Run a read-only method and get the decoded result directly.
+const { result: balance, isReadCall } = await rpc.queryContract<bigint>(
+  tokenId,
+  "balance",
+  { id: "G..." } // named args, keyed by parameter name; omit for no-arg methods
+);
+
+// Discover a contract's callable methods from just its ID.
+const methods = await rpc.getContractMethods(tokenId);
+// [{ name: "balance", inputs: [{ name: "id", type: "Address" }], outputs: ["I128"] }, ...]
+```
+
+`isReadCall` is per-call: `false` means the `result` is only a simulation preview of a call that would change state (apply it by signing a transaction via `contract.Client`).
+
+<details>
+<summary><b>Advanced: read a raw ledger entry</b></summary>
+
+Reach for `getLedgerEntries` only when you need a specific storage key that isn't exposed as a contract method.
+
 ```typescript
 import * as StellarSdk from "@stellar/stellar-sdk";
 import { rpc } from "@/lib/stellar";
@@ -597,6 +669,8 @@ export async function getContractData(
   );
 }
 ```
+
+</details>
 
 ## Smart Accounts (Passkey Wallets)
 


### PR DESCRIPTION
## What

Re-grounds the SDK-mechanics sections of the `dapp` skill against the official [JS SDK docs](https://stellar.github.io/js-stellar-sdk/) (v16), which now publish `llms.txt` / `llms-full.txt` bundles for AI tools. Several patterns in the skill had drifted from what the docs treat as canonical.

## Changes

- **Node 22 requirement.** Skill said Node 20+; SDK v16 requires Node 22 (`engines: >=22.0.0`). Added notes that `@stellar/stellar-base` is folded into `@stellar/stellar-sdk`, the SDK is ESM-first, and it uses native `fetch`.
- **Lead contract invocation with `contract.Client`.** The docs' canonical "Invoke a Contract" guide uses `Client.from<T>()` → `method()` → `signAndSend()`, and calls `AssembledTransaction` the "main workhorse." The skill only showed the low-level `Contract.call` + `assembleTransaction` path. Now the typed client is primary; the low-level path is kept as an advanced note (using `prepareTransaction`).
- **Bounded polling.** Replaced the hand-rolled unbounded `while (status === "NOT_FOUND")` loop with `rpc.pollTransaction`.
- **One-line contract reads.** Added `rpc.queryContract` / `rpc.getContractMethods`; kept manual `getLedgerEntries` as an advanced fallback.
- **Typed errors.** Balance example now branches on `NotFoundError` instead of `error.response?.status === 404`, and points to Horizon result codes for submission failures.
- **Sourcing note.** Documents that SDK mechanics track the JS SDK docs, while wallet (Freighter, Stellar Wallets Kit), passkey/smart-account, and OpenZeppelin relayer sections are separate packages and should be verified against their own upstream docs (not done in this PR).

## Why

Skills are consumed by AI agents that copy examples verbatim. The old contract-invocation and polling patterns still compile but are lower-level than the docs recommend, and the Node version was factually wrong.

## Notes for reviewers

- **Stacked on #41.** This branch is based on `fix/skill-audit-example-code-and-dedup` (PR #41), which also edits `dapp/SKILL.md` and hasn't merged yet. Until #41 merges, this PR's diff includes #41's commits. Merge #41 first, then this narrows to just the dapp SDK update.
- The wallet / passkey / relayer / React sections were intentionally left unchanged this pass (out of scope: not part of the JS SDK docs).