### PR TITLE
Update smart contract CLI examples

### DIFF
--- a/skills/assets/SKILL.md
+++ b/skills/assets/SKILL.md
@@ -266,7 +266,7 @@ SAC provides a smart-contract interface for Stellar Assets, enabling smart contr
 # Get the SAC address for an asset
 stellar contract asset deploy \
   --asset USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN \
-  --source alice \
+  --source-account alice \
   --network testnet
 ```
 

--- a/skills/smart-contracts/SKILL.md
+++ b/skills/smart-contracts/SKILL.md
@@ -134,16 +134,16 @@ Full patterns (three storage types, auth variants, cross-contract calls, events,
 ## Build, deploy, invoke
 
 ```bash
-# Build optimized WASM → target/wasm32-unknown-unknown/release/*.wasm
+# Build optimized WASM → target/wasm32v1-none/release/*.wasm
 stellar contract build
 
 # Create and fund an identity (testnet)
-stellar keys generate --global alice --network testnet --fund
+stellar keys generate alice --network testnet --fund
 
 # Deploy (constructor args go after the `--`)
 stellar contract deploy \
-  --wasm target/wasm32-unknown-unknown/release/my_contract.wasm \
-  --source alice \
+  --wasm target/wasm32v1-none/release/my_contract.wasm \
+  --source-account alice \
   --network testnet \
   -- \
   --admin alice
@@ -151,7 +151,7 @@ stellar contract deploy \
 # Invoke
 stellar contract invoke \
   --id CONTRACT_ID \
-  --source alice \
+  --source-account alice \
   --network testnet \
   -- \
   increment

--- a/skills/smart-contracts/development.md
+++ b/skills/smart-contracts/development.md
@@ -126,7 +126,7 @@ Import another contract's WASM to get a typed client:
 ```rust
 mod token_contract {
     soroban_sdk::contractimport!(
-        file = "../token/target/wasm32-unknown-unknown/release/token.wasm"
+        file = "../token/target/wasm32v1-none/release/token.wasm"
     );
 }
 
@@ -252,9 +252,9 @@ Worked examples: [soroban-examples](https://github.com/stellar/soroban-examples)
 The 64KB limit is real and the release profile in [SKILL.md](SKILL.md#project-setup) is mandatory. If you still exceed it:
 
 ```bash
-ls -la target/wasm32-unknown-unknown/release/*.wasm   # check size
+ls -la target/wasm32v1-none/release/*.wasm   # check size
 cargo install cargo-bloat
-cargo bloat --release --target wasm32-unknown-unknown # find heavy deps
+cargo bloat --release --target wasm32v1-none # find heavy deps
 ```
 
 Then: split the contract, drop heavy dependencies, prefer `symbol_short!`, avoid large static data.
@@ -277,7 +277,7 @@ Fees are multidimensional (CPU instructions, ledger reads/writes, bytes, events,
 | `cannot find macro println` / `std` errors | Missing `#![no_std]` | Add as first line of `lib.rs`; use SDK types |
 | Calls fail after inactivity, data "missing" | Storage TTL expired → archived | Extend TTLs proactively; restore archived entries |
 | Temporary data vanished | Wrong storage type | Use `persistent()` for data that must survive |
-| `Error: identity "alice" not found` | CLI identity missing | `stellar keys generate --global alice --network testnet --fund` |
+| `Error: identity "alice" not found` | CLI identity missing | `stellar keys generate alice --network testnet --fund` |
 | `invalid argument format` on invoke | Wrong CLI arg syntax | Plain strings for addresses; JSON for complex types |
 | `transaction simulation failed` | Soroban tx not simulated/assembled | Simulate, then `assembleTransaction` before signing |
 | `tx_bad_auth` | Wrong network passphrase or signer | Match passphrase to network; check signing identity |

--- a/skills/smart-contracts/testing.md
+++ b/skills/smart-contracts/testing.md
@@ -103,9 +103,9 @@ let vault_id = env.register(VaultContract, ());
 
 ```bash
 stellar container start local     # or: docker run --rm -it -p 8000:8000 stellar/quickstart:latest --local
-stellar keys generate --global test-account --network local --fund
-stellar contract deploy --wasm target/wasm32-unknown-unknown/release/contract.wasm \
-  --source test-account --network local
+stellar keys generate test-account --network local --fund
+stellar contract deploy --wasm target/wasm32v1-none/release/contract.wasm \
+  --source-account test-account --network local
 ```
 
 Endpoints: RPC `http://localhost:8000/soroban/rpc`, Horizon `http://localhost:8000`, passphrase `"Standalone Network ; February 2017"`.
@@ -113,8 +113,8 @@ Endpoints: RPC `http://localhost:8000/soroban/rpc`, Horizon `http://localhost:80
 ## Testnet
 
 ```bash
-stellar keys generate --global my-key --network testnet --fund
-stellar contract deploy --wasm ... --source my-key --network testnet
+stellar keys generate my-key --network testnet --fund
+stellar contract deploy --wasm ... --source-account my-key --network testnet
 ```
 
 - RPC: `https://soroban-testnet.stellar.org` · Horizon: `https://horizon-testnet.stellar.org`
@@ -207,7 +207,7 @@ Three techniques worth knowing; each is one command plus a doc link:
 ## Resource profiling
 
 ```bash
-stellar contract invoke --id CONTRACT_ID --source alice --network testnet \
+stellar contract invoke --id CONTRACT_ID --source-account alice --network testnet \
   --send=no -- function_name --arg value
 ```
 
@@ -224,9 +224,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - run: rustup target add wasm32-unknown-unknown
+      - run: rustup target add wasm32v1-none
       - run: cargo test
-      - run: cargo build --release --target wasm32-unknown-unknown
+      - run: cargo build --release --target wasm32v1-none
 ```
 
 For integration jobs, run `stellar/quickstart` as a service container and deploy with the CLI (`cargo install stellar-cli --locked`).


### PR DESCRIPTION
## Summary

- update smart-contract examples from `wasm32-unknown-unknown` to `wasm32v1-none`
- remove obsolete `stellar keys generate --global` usage
- prefer canonical `--source-account` in contract deploy/invoke and SAC examples

Closes #44.

## Why

Current Stellar Docs say `stellar contract build` targets `wasm32v1-none` and emits artifacts under `target/wasm32v1-none/release/`. Current `stellar 27.0.0` CLI help uses `--source-account <SOURCE_ACCOUNT>` for deploy/invoke, while `--source` remains accepted as an alias. `stellar keys generate --help` no longer lists `--global`.

## Verification

- `rg -n "wasm32-unknown-unknown|--global|--source " skills/smart-contracts skills/assets` returns no matches
- `git diff --check`
