### PR TITLE
Add Agent Browser WebAuthn community skill

### DIFF
--- a/site/src/data/skills.ts
+++ b/site/src/data/skills.ts
@@ -165,4 +165,12 @@ export const ECOSYSTEM_CARDS: readonly EcosystemCardSource[] = [
     copyValue:
       "https://github.com/Trustless-Work/trustless-work-dev-skill/blob/main/SKILL.md",
   },
+  {
+    title: "Agent Browser WebAuthn",
+    description:
+      "Drive passkey and Stellar smart-account browser tests with agent-browser and Chrome DevTools virtual WebAuthn authenticators.",
+    pathLabel: "kalepail/skills",
+    copyValue:
+      "https://github.com/kalepail/skills/blob/main/skills/agent-browser-webauthn/SKILL.md",
+  },
 ] as const;

--- a/site/src/data/skills.ts
+++ b/site/src/data/skills.ts
@@ -168,7 +168,7 @@ export const ECOSYSTEM_CARDS: readonly EcosystemCardSource[] = [
   {
     title: "Agent Browser WebAuthn",
     description:
-      "Drive passkey and Stellar smart-account browser tests with agent-browser and Chrome DevTools virtual WebAuthn authenticators.",
+      "Drive passkey and Stellar smart account browser tests with agent-browser and Chrome DevTools virtual WebAuthn authenticators.",
     pathLabel: "kalepail/skills",
     copyValue:
       "https://github.com/kalepail/skills/blob/main/skills/agent-browser-webauthn/SKILL.md",


### PR DESCRIPTION
## Summary

Adds Kalepail's Agent Browser WebAuthn skill to the community skills directory.

The skill helps agents test passkey, WebAuthn, and Stellar smart-account browser flows by wrapping `agent-browser` commands with a Chrome DevTools virtual authenticator.

## Validation

- Published skill repo: https://github.com/kalepail/skills
- Validated the skill with `quick_validate.py`
- Ran the helper help path with Node.js
- Ran `pnpm lint:ts` in `site/`
