### PR TITLE
Add PRISM bounded agent treasury to community skills

### DIFF
--- a/site/src/data/skills.ts
+++ b/site/src/data/skills.ts
@@ -165,4 +165,11 @@ export const ECOSYSTEM_CARDS: readonly EcosystemCardSource[] = [
     copyValue:
       "https://github.com/Trustless-Work/trustless-work-dev-skill/blob/main/SKILL.md",
   },
+  {
+    title: "PRISM Bounded Agent Treasury",
+    description:
+      "Give an AI agent a non-custodial, contract-bounded spending account on Stellar with PRISM. Covers treasury deployment with per-payment and rolling daily limits, payee whitelists, time-bound agent session keys, escrow, x402-gated payments, and Groth16/BN254 ZK compliance proofs verified on-chain.",
+    pathLabel: "Bekirerdem/prism",
+    copyValue: "https://github.com/Bekirerdem/prism/blob/main/SKILL.md",
+  },
 ] as const;


### PR DESCRIPTION
Adds [PRISM](https://github.com/Bekirerdem/prism) to `ECOSYSTEM_CARDS`, following the entry format from the "Add your skill" section on skills.stellar.org.

**What the skill covers:** giving an AI agent a non-custodial, contract-bounded spending account on Stellar — treasury deployment with per-payment + rolling daily limits, payee whitelists, time-bound spend-capped agent session keys, escrow, x402-gated payments, and Groth16/BN254 (Protocol 25 X-Ray host functions) ZK compliance proofs verified on-chain. It complements the official `agentic-payments` and `zk-proofs` skills with a concrete, deployed BN254/Poseidon walkthrough and includes a "Gotchas" section of non-obvious facts (rolling 24h window, SAC trustline failures, `getEvents` paging, session-replaces-agent semantics).

**SKILL.md:** https://github.com/Bekirerdem/prism/blob/main/SKILL.md

**Project status:** MIT-licensed, live on testnet (contracts + web app at prism-stellar.vercel.app), built during Build On Stellar IBW 2026 (2nd place, Agentic track) and Stellar Hacks: Real-World ZK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)