### PR TITLE
Add ROZO Intents ecosystem skill card

### DIFF
--- a/site/src/data/skills.ts
+++ b/site/src/data/skills.ts
@@ -180,6 +180,5 @@ export const ECOSYSTEM_CARDS: readonly EcosystemCardSource[] = [
     pathLabel: "RozoAI/rozo-intents-skills",
     copyValue:
       "https://github.com/RozoAI/rozo-intents-skills/blob/main/SKILL.md",
-    category: "Ecosystem",
   },
 ] as const;

--- a/site/src/data/skills.ts
+++ b/site/src/data/skills.ts
@@ -179,7 +179,7 @@ export const ECOSYSTEM_CARDS: readonly EcosystemCardSource[] = [
       "Send USDC and USDT across Stellar, Ethereum, Arbitrum, Base, BSC, Polygon, and Solana using natural language. Covers cross-chain bridging, wallet detection, fee estimation, tiered confirmation logic, and QR code payment parsing inside Claude Code.",
     pathLabel: "RozoAI/rozo-intents-skills",
     copyValue:
-      "https://github.com/RozoAI/rozo-intents-skills/blob/main/README.md",
+      "https://github.com/RozoAI/rozo-intents-skills/blob/main/SKILL.md",
     category: "Ecosystem",
   },
 ] as const;

--- a/site/src/data/skills.ts
+++ b/site/src/data/skills.ts
@@ -173,4 +173,13 @@ export const ECOSYSTEM_CARDS: readonly EcosystemCardSource[] = [
     copyValue:
       "https://github.com/kalepail/skills/blob/main/skills/agent-browser-webauthn/SKILL.md",
   },
+  {
+    title: "ROZO Intents",
+    description:
+      "Send USDC and USDT across Stellar, Ethereum, Arbitrum, Base, BSC, Polygon, and Solana using natural language. Covers cross-chain bridging, wallet detection, fee estimation, tiered confirmation logic, and QR code payment parsing inside Claude Code.",
+    pathLabel: "rozoai/rozo-intents",
+    copyValue:
+      "https://github.com/RozoAI/rozo-intents-skills/blob/main/README.md",
+    category: "Ecosystem",
+  },
 ] as const;

--- a/site/src/data/skills.ts
+++ b/site/src/data/skills.ts
@@ -177,7 +177,7 @@ export const ECOSYSTEM_CARDS: readonly EcosystemCardSource[] = [
     title: "ROZO Intents",
     description:
       "Send USDC and USDT across Stellar, Ethereum, Arbitrum, Base, BSC, Polygon, and Solana using natural language. Covers cross-chain bridging, wallet detection, fee estimation, tiered confirmation logic, and QR code payment parsing inside Claude Code.",
-    pathLabel: "rozoai/rozo-intents",
+    pathLabel: "RozoAI/rozo-intents-skills",
     copyValue:
       "https://github.com/RozoAI/rozo-intents-skills/blob/main/README.md",
     category: "Ecosystem",


### PR DESCRIPTION
## Summary
Adds the ROZO Intents community skill card to the Stellar Skills landing page.

## What changed
- `site/src/data/skills.ts`: appended one entry to `ECOSYSTEM_CARDS`:
  - **Title:** ROZO Intents
  - **Path label:** `RozoAI/rozo-intents-skills`
  - **Copy URL:** `https://github.com/RozoAI/rozo-intents-skills/blob/main/SKILL.md`

## Why
ROZO Intents is an active community skill for cross-chain USDC/USDT payments and bridging via natural language, with Stellar as a supported chain. Listing it makes the project discoverable to developers browsing skills.stellar.org.

## Verification
- [x] `pnpm lint:ts` passes
- [x] `pnpm lint` passes
- [x] `pnpm build` succeeds and produces `out/`
- [x] ROZO Intents card renders server-side in `out/index.html`
- [x] Copy button copies the SKILL.md URL above
