### PR TITLE
docs: add Raven MCP server to the skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ This skill provides AI assistants with deep knowledge of the current Stellar dev
 - **Security**: Smart contract security patterns, audit checklists
 - **Ecosystem**: DeFi protocols, developer tools, community projects
 
-## Raven — live MCP server
+## Raven: live MCP server
 
-These skills give your agent durable Stellar context, baked in. [Raven](https://raven.stellar.buzz) is a complementary **remote MCP server (Model Context Protocol)** for on-demand lookups: connect an agent and it searches Stellar docs and live ecosystem data, cross-referenced into single answers. Its catalog also includes these skills, so Raven is a live delivery gateway for them. Use both — skills for durable best practices, Raven for current lookups.
+These skills give your agent durable Stellar context, baked in. [Raven](https://raven.stellar.buzz) is a complementary **remote Model Context Protocol (MCP) server** for on-demand lookups: connect an agent and it searches Stellar docs and live ecosystem data, cross-referenced into single answers. Its catalog also includes these skills, so Raven is a live delivery gateway for them. Use both: skills for durable best practices, Raven for current lookups.
 
 Raven is open source at [kalepail/stellar-raven](https://github.com/kalepail/stellar-raven). Connect it in Claude Code:
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,18 @@ This skill provides AI assistants with deep knowledge of the current Stellar dev
 - **Security**: Smart contract security patterns, audit checklists
 - **Ecosystem**: DeFi protocols, developer tools, community projects
 
+## Raven — live MCP server
+
+These skills give your agent durable Stellar context, baked in. [Raven](https://raven.stellar.buzz) is a complementary **remote MCP server (Model Context Protocol)** for on-demand lookups: connect an agent and it searches Stellar docs and live ecosystem data, cross-referenced into single answers. Its catalog also includes these skills, so Raven is a live delivery gateway for them. Use both — skills for durable best practices, Raven for current lookups.
+
+Raven is open source at [kalepail/stellar-raven](https://github.com/kalepail/stellar-raven). Connect it in Claude Code:
+
+```bash
+claude mcp add --transport http stellar-raven "https://raven.stellar.buzz/mcp"
+```
+
+You can also try Raven in the browser at the [playground](https://raven.stellar.buzz/playground), a hosted chat UI for asking Raven questions (sign-in required).
+
 ## Installing
 
 These skills work with any agent that supports the [Agent Skills](https://agentskills.io) standard.

--- a/site/src/data/skills.ts
+++ b/site/src/data/skills.ts
@@ -125,7 +125,7 @@ export const SKILL_CARD_SOURCES: readonly SkillCardSource[] = [
     category: "Ecosystem",
     title: "SEPs, CAPs & Ecosystem",
     description:
-      "Pick the right SEP or CAP for your feature, with ecosystem projects and curated reference links.",
+      "Pick the right SEP or CAP for your feature, with ecosystem projects, curated reference links, and MCPs.",
   },
 ] as const;
 

--- a/skills/standards/SKILL.md
+++ b/skills/standards/SKILL.md
@@ -371,7 +371,7 @@ Rust SDK for smart contract development.
 ### AI & MCP Tools
 
 #### Raven
-Remote MCP (Model Context Protocol) server for AI agents — searches Stellar docs and live ecosystem data, cross-referenced into single answers. Its catalog also serves these skills.
+Remote Model Context Protocol (MCP) server for AI agents. Searches Stellar docs and live ecosystem data, cross-referenced into single answers. Its catalog also serves these skills.
 - **Server**: https://raven.stellar.buzz (MCP endpoint: https://raven.stellar.buzz/mcp)
 - **Playground**: https://raven.stellar.buzz/playground (hosted chat UI for humans; sign-in required)
 - **GitHub**: https://github.com/kalepail/stellar-raven

--- a/skills/standards/SKILL.md
+++ b/skills/standards/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: standards
-description: Stellar standards, ecosystem, and reference. Covers SEPs (Stellar Ecosystem Proposals), CAPs (Core Advancement Proposals), and a quick map for picking the right standard for wallets, anchors, payments, deposits/withdrawals, federation, deep links, and KYC. Also bundles ecosystem references (DeFi protocols, dev tools, wallets, infra, community projects) and curated documentation links. Use when you need to know which SEP applies, or want a starting point for ecosystem integrations and official docs.
+description: Stellar standards, ecosystem, and reference. Covers SEPs (Stellar Ecosystem Proposals), CAPs (Core Advancement Proposals), and a quick map for picking the right standard for wallets, anchors, payments, deposits/withdrawals, federation, deep links, and KYC. Also bundles ecosystem references (DeFi protocols, dev tools, wallets, infra, community projects), curated documentation links, and MCP servers (live tools such as Raven). Use when you need to know which SEP applies, or want a starting point for ecosystem integrations, official docs, or live MCP tooling.
 user-invocable: true
 argument-hint: "[standards or ecosystem lookup]"
 ---
@@ -367,6 +367,16 @@ Official JavaScript/TypeScript SDK.
 Rust SDK for smart contract development.
 - **GitHub**: https://github.com/stellar/rs-soroban-sdk
 - **Crate**: `soroban-sdk`
+
+### AI & MCP Tools
+
+#### Raven
+Remote MCP (Model Context Protocol) server for AI agents — searches Stellar docs and live ecosystem data, cross-referenced into single answers. Its catalog also serves these skills.
+- **Server**: https://raven.stellar.buzz (MCP endpoint: https://raven.stellar.buzz/mcp)
+- **Playground**: https://raven.stellar.buzz/playground (hosted chat UI for humans; sign-in required)
+- **GitHub**: https://github.com/kalepail/stellar-raven
+- **Connect (Claude Code)**: `claude mcp add --transport http stellar-raven "https://raven.stellar.buzz/mcp"`
+- **Tools**: `search`, `execute`
 
 ## Oracles
 


### PR DESCRIPTION
Closes #58.

Adds **Raven** (a remote MCP server, open source at [kalepail/stellar-raven](https://github.com/kalepail/stellar-raven)) as the live companion to the installed skills. Framing: the skills give an agent durable, installed best-practice context; Raven is the live, hosted MCP server for on-demand lookups of docs and current ecosystem data (and its catalog serves these skills too).

### Changes
- **README.md** — new "Raven — live MCP server" section (complementary framing, connect command, open-source + playground links).
- **skills/standards/SKILL.md** — the frontmatter `description` now mentions MCP servers, and a new "AI & MCP Tools" entry documents Raven under Developer Tools.
- **site/src/data/skills.ts** — the "SEPs, CAPs & Ecosystem" card copy now includes MCPs.
