### PR TITLE
chore(site): update analytics to new GTM container + GA4

### DIFF
--- a/site/src/app/layout.tsx
+++ b/site/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata, Viewport } from "next";
-import { GoogleTagManager } from "@next/third-parties/google";
+import { GoogleTagManager, GoogleAnalytics } from "@next/third-parties/google";
 
 import "@stellar/design-system/build/styles.min.css";
 import "@/styles/globals.scss";
@@ -74,7 +74,12 @@ export default function RootLayout({
     <html lang="en">
       <body className="sds-theme-light" data-sds-theme="sds-theme-light">
         <div id="root">{children}</div>
-        {GA_TRACKING_ENABLED && <GoogleTagManager gtmId="GTM-KCNDDL3" />}
+        {GA_TRACKING_ENABLED && (
+          <>
+            <GoogleTagManager gtmId="GTM-KPV99TKH" />
+            <GoogleAnalytics gaId="G-6PQ8C6FJSR" />
+          </>
+        )}
       </body>
     </html>
   );


### PR DESCRIPTION
## What

Updates the analytics tags on [skills.stellar.org](https://skills.stellar.org) per Alexis (marketing).

- Replaces GTM container `GTM-KCNDDL3` → `GTM-KPV99TKH`
- Adds GA4 (`G-6PQ8C6FJSR`) via `@next/third-parties`'s `GoogleAnalytics`

Both load through the framework components (equivalent to the raw GTM/GA4 snippets) and stay behind the existing production-only `GA_TRACKING_ENABLED` gate, so nothing fires on localhost or PR previews.

## Note / open question

The site now loads **GTM and GA4 directly**. If the `GTM-KPV99TKH` container is *also* configured to fire a GA4 tag for `G-6PQ8C6FJSR`, pageviews will be double-counted. Confirming intended setup with marketing; may follow up with a tweak to fire GA4 from only one source.

## Testing

- `GTM-KCNDDL3` fully removed; only the two new IDs remain in `site/`
- Not yet run locally (`node_modules` not installed in this checkout): please run `pnpm lint:ts`, `pnpm lint`, `pnpm build` before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)