### PR TITLE
Add Anchors community skill card (carries #35)

### DIFF
--- a/site/src/data/skills.ts
+++ b/site/src/data/skills.ts
@@ -177,6 +177,5 @@ export const ECOSYSTEM_CARDS: readonly EcosystemCardSource[] = [
     pathLabel: "CheesecakeLabs/stellar-anchor-skill",
     copyValue:
       "https://github.com/CheesecakeLabs/stellar-anchor-skill/blob/main/SKILL.md",
-    category: "Ecosystem",
   },
 ] as const;

--- a/site/src/data/skills.ts
+++ b/site/src/data/skills.ts
@@ -173,7 +173,7 @@ export const ECOSYSTEM_CARDS: readonly EcosystemCardSource[] = [
   {
     title: "Anchors",
     description:
-      "Teach your AI coding agent how to integrate with and build Stellar anchors (fiat on/off-ramps).",
+      "Integrate with or build Stellar anchors — fiat on/off-ramps, deposit/withdrawal, KYC, RFQ, cross-border remittance. The implementation layer for SEPs 1/6/10/12/24/31/38: what to build, in what order, and the gotchas (memo contracts, trustline traps, state machine) that bite.",
     pathLabel: "CheesecakeLabs/stellar-anchor-skill",
     copyValue:
       "https://github.com/CheesecakeLabs/stellar-anchor-skill/blob/main/SKILL.md",

--- a/site/src/data/skills.ts
+++ b/site/src/data/skills.ts
@@ -173,7 +173,7 @@ export const ECOSYSTEM_CARDS: readonly EcosystemCardSource[] = [
   {
     title: "Anchors",
     description:
-      "Integrate with or build Stellar anchors — fiat on/off-ramps, deposit/withdrawal, KYC, RFQ, cross-border remittance. The implementation layer for SEPs 1/6/10/12/24/31/38: what to build, in what order, and the gotchas (memo contracts, trustline traps, state machine) that bite.",
+      "Integrate with or build Stellar anchors (fiat on/off-ramps, deposits/withdrawals, KYC). Covers core SEP flows (1/6/10/12/24/31/38) and common integration pitfalls.",
     pathLabel: "CheesecakeLabs/stellar-anchor-skill",
     copyValue:
       "https://github.com/CheesecakeLabs/stellar-anchor-skill/blob/main/SKILL.md",

--- a/site/src/data/skills.ts
+++ b/site/src/data/skills.ts
@@ -170,4 +170,13 @@ export const ECOSYSTEM_CARDS: readonly EcosystemCardSource[] = [
       "https://github.com/Trustless-Work/trustless-work-dev-skill/blob/main/SKILL.md",
     category: "Ecosystem",
   },
+  {
+    title: "Anchors",
+    description:
+      "Teach your AI coding agent how to integrate with and build Stellar anchors (fiat on/off-ramps).",
+    pathLabel: "CheesecakeLabs/stellar-anchor-skill",
+    copyValue:
+      "https://github.com/CheesecakeLabs/stellar-anchor-skill/blob/main/SKILL.md",
+    category: "Ecosystem",
+  },
 ] as const;


### PR DESCRIPTION
Carries #35 by @phelipe-ckl with one fix on top: the branch predates #40, and `EcosystemCardSource` no longer has a `category` field, so the card as written fails `tsc --noEmit` once merged with current main. Dropped that one line and verified the merge result passes `pnpm lint:ts`.

The original commits are untouched, so merging this will mark #35 as merged and authorship stays with @phelipe-ckl. GitHub doesn't allow maintainer edits on organization forks, which is why the fix couldn't go directly onto the CheesecakeLabs branch.