### PR TITLE
Add ROZO Intents community skill card (carries #54)

### DIFF
--- a/site/src/data/skills.ts
+++ b/site/src/data/skills.ts
@@ -180,6 +180,5 @@ export const ECOSYSTEM_CARDS: readonly EcosystemCardSource[] = [
     pathLabel: "RozoAI/rozo-intents-skills",
     copyValue:
       "https://github.com/RozoAI/rozo-intents-skills/blob/main/SKILL.md",
-    category: "Ecosystem",
   },
 ] as const;

--- a/site/src/data/skills.ts
+++ b/site/src/data/skills.ts
@@ -179,7 +179,7 @@ export const ECOSYSTEM_CARDS: readonly EcosystemCardSource[] = [
       "Send USDC and USDT across Stellar, Ethereum, Arbitrum, Base, BSC, Polygon, and Solana using natural language. Covers cross-chain bridging, wallet detection, fee estimation, tiered confirmation logic, and QR code payment parsing inside Claude Code.",
     pathLabel: "RozoAI/rozo-intents-skills",
     copyValue:
-      "https://github.com/RozoAI/rozo-intents-skills/blob/main/README.md",
+      "https://github.com/RozoAI/rozo-intents-skills/blob/main/SKILL.md",
     category: "Ecosystem",
   },
 ] as const;

--- a/site/src/data/skills.ts
+++ b/site/src/data/skills.ts
@@ -173,4 +173,13 @@ export const ECOSYSTEM_CARDS: readonly EcosystemCardSource[] = [
     copyValue:
       "https://github.com/kalepail/skills/blob/main/skills/agent-browser-webauthn/SKILL.md",
   },
+  {
+    title: "ROZO Intents",
+    description:
+      "Send USDC and USDT across Stellar, Ethereum, Arbitrum, Base, BSC, Polygon, and Solana using natural language. Covers cross-chain bridging, wallet detection, fee estimation, tiered confirmation logic, and QR code payment parsing inside Claude Code.",
+    pathLabel: "rozoai/rozo-intents",
+    copyValue:
+      "https://github.com/RozoAI/rozo-intents-skills/blob/main/README.md",
+    category: "Ecosystem",
+  },
 ] as const;

--- a/site/src/data/skills.ts
+++ b/site/src/data/skills.ts
@@ -177,7 +177,7 @@ export const ECOSYSTEM_CARDS: readonly EcosystemCardSource[] = [
     title: "ROZO Intents",
     description:
       "Send USDC and USDT across Stellar, Ethereum, Arbitrum, Base, BSC, Polygon, and Solana using natural language. Covers cross-chain bridging, wallet detection, fee estimation, tiered confirmation logic, and QR code payment parsing inside Claude Code.",
-    pathLabel: "rozoai/rozo-intents",
+    pathLabel: "RozoAI/rozo-intents-skills",
     copyValue:
       "https://github.com/RozoAI/rozo-intents-skills/blob/main/README.md",
     category: "Ecosystem",


### PR DESCRIPTION
Carries #54 by @akbarsaputrait plus a merge of main that resolves the ECOSYSTEM_CARDS append conflict (the Anchors and PRISM cards landed in the meantime; the ROZO card moved to the end). `pnpm lint:ts` passes on the result.

Original commits are untouched, so merging this with a merge commit will mark #54 as merged and authorship stays with the author. GitHub returned 403 on a direct push to the organization fork despite the PR reporting maintainer edits as allowed, hence the carry.