### PR TITLE
Add the Stellar Scout community skill card

### DIFF
--- a/site/src/data/skills.ts
+++ b/site/src/data/skills.ts
@@ -260,4 +260,11 @@ export const ECOSYSTEM_CARDS: readonly EcosystemCardSource[] = [
     copyValue:
       "https://github.com/lumenloop/lumenloop-skills/blob/main/skills/stellar-project-dossier/SKILL.md",
   },
+  {
+    title: "Stellar Scout",
+    description:
+      "Scout the Stellar ecosystem before you build: validate ideas against shipped projects, match open SCF-funded RFPs, draft SCF pitches, find audit firms, and pull cited prior art from 2,000+ indexed repos.",
+    pathLabel: "stellarlight.xyz/scout",
+    copyValue: "https://stellarlight.xyz/skills/stellar-scout.md",
+  },
 ] as const;


### PR DESCRIPTION
Closes #36 — the remaining Stellarlight half; the LumenLoop half shipped in #69.

Adds one card for [Stellar Scout](https://stellarlight.xyz/scout), Stellarlight's research skill for the strategic layer of building on Stellar: idea validation against shipped projects, open SCF-funded RFP matching, SCF pitch drafting, audit-firm lookup, and cited prior art over 2,000+ indexed repos.

Two things worth noting from vetting:

- The skill is hosted on stellarlight.xyz rather than GitHub (`https://stellarlight.xyz/skills/stellar-scout.md`), so the card's path label points at the product page instead of an `owner/repo`. `EcosystemCardSource.copyValue` is documented as "fully-qualified external URLs (typically GitHub)", so this fits the type's intent.
- Content bar: MIT, read-only research over Stellarlight's public API, no key handling or payment execution, well-formed frontmatter — and it explicitly defers to the official skills.stellar.org skills for the how-to-build layer, chaining into them by name.

Verified: `pnpm lint:ts`, `pnpm lint`, and `pnpm build` pass; the card server-renders in `out/index.html`.