### PR TITLE
Add Cogladius to community skills

### DIFF
--- a/site/src/data/skills.ts
+++ b/site/src/data/skills.ts
@@ -267,4 +267,12 @@ export const ECOSYSTEM_CARDS: readonly EcosystemCardSource[] = [
     pathLabel: "stellarlight.xyz/scout",
     copyValue: "https://stellarlight.xyz/skills/stellar-scout.md",
   },
+  {
+    title: "Cogladius",
+    description:
+      "Register your AI agent to earn XLM by completing on-chain tasks. Covers permissionless one-call registration, task polling, submitting solutions, and how the non-custodial Soroban escrow releases the XLM reward on an on-chain, ed25519-verified judge verdict.",
+    pathLabel: "furkanyesildag/cogladius",
+    copyValue:
+      "https://github.com/furkanyesildag/cogladius/blob/main/SKILL.md",
+  },
 ] as const;

--- a/site/src/data/skills.ts
+++ b/site/src/data/skills.ts
@@ -295,7 +295,7 @@ export const ECOSYSTEM_CARDS: readonly EcosystemCardSource[] = [
   {
     title: "Cogladius",
     description:
-      "Register your AI agent to earn XLM by completing on-chain tasks. Covers permissionless one-call registration, task polling, submitting solutions, and how the non-custodial Soroban escrow releases the XLM reward on an on-chain, ed25519-verified judge verdict.",
+      "Register an AI agent to earn XLM by completing on-chain tasks: one-call permissionless registration, task polling, solution submission, and payout from a non-custodial Soroban escrow on an ed25519-verified judge verdict.",
     pathLabel: "furkanyesildag/cogladius",
     copyValue:
       "https://github.com/furkanyesildag/cogladius/blob/main/SKILL.md",


### PR DESCRIPTION
Adds **Cogladius** to `ECOSYSTEM_CARDS`.

Cogladius is a permissionless task marketplace on Stellar. Humans post tasks with an XLM reward locked in a non-custodial Soroban escrow; autonomous AI agents compete to solve them; a three-judge AI panel scores submissions and the escrow contract releases the XLM reward to the winner on an on-chain, ed25519-verified verdict.

The SKILL.md teaches an AI agent to register (one permissionless API call), poll open tasks, solve, and submit to earn XLM.

- Skill: https://github.com/furkanyesildag/cogladius/blob/main/SKILL.md
- Product (live on mainnet): https://cogladius.xyz
- Repo: https://github.com/furkanyesildag/cogladius