### PR TITLE
Add Sub Rosa community skill

### DIFF
--- a/site/src/data/skills.ts
+++ b/site/src/data/skills.ts
@@ -267,4 +267,12 @@ export const ECOSYSTEM_CARDS: readonly EcosystemCardSource[] = [
     pathLabel: "stellarlight.xyz/scout",
     copyValue: "https://stellarlight.xyz/skills/stellar-scout.md",
   },
+  {
+    title: "Sub Rosa",
+    description:
+      "Integrate sealed coordination into Stellar apps with @sub-rosa/sdk: run sealed-bid asset auctions with SAC escrow and atomic lot settlement, confidential proposal rounds, Drand-timed reveal, permissionless lifecycle automation, and verifiable Core v2 receipts.",
+    pathLabel: "karagozemin/Sub-Rosa",
+    copyValue:
+      "https://github.com/karagozemin/Sub-Rosa/blob/feat/core-v2/skills/sub-rosa/SKILL.md",
+  },
 ] as const;

--- a/site/src/data/skills.ts
+++ b/site/src/data/skills.ts
@@ -290,7 +290,7 @@ export const ECOSYSTEM_CARDS: readonly EcosystemCardSource[] = [
       "Integrate sealed coordination into Stellar apps with @sub-rosa/sdk: run sealed-bid asset auctions with SAC escrow and atomic lot settlement, confidential proposal rounds, Drand-timed reveal, permissionless lifecycle automation, and verifiable Core v2 receipts.",
     pathLabel: "karagozemin/Sub-Rosa",
     copyValue:
-      "https://github.com/karagozemin/Sub-Rosa/blob/feat/core-v2/skills/sub-rosa/SKILL.md",
+      "https://github.com/karagozemin/Sub-Rosa/blob/main/skills/sub-rosa/SKILL.md",
   },
   {
     title: "ROZO Checkout",


### PR DESCRIPTION
## Summary

- list the Sub Rosa Agent Skill in the Community Skills catalog
- link directly to the public skill maintained with the Sub Rosa Core v2 SDK
- cover sealed-bid asset auctions, confidential proposal rounds, Drand reveal, SAC escrow and atomic settlement, lifecycle automation, receipts, and current testnet safety boundaries

## Skill source

https://github.com/karagozemin/Sub-Rosa/blob/feat/core-v2/skills/sub-rosa/SKILL.md

## Validation

- Agent Skills `quick_validate.py`: passed
- `pnpm lint`: passed
- `pnpm lint:ts`: passed
- `pnpm build`: passed
- verified the skill URL is publicly readable and the card appears in the static site and generated `llms.txt`