### PR TITLE
Rename PRISM community skill to Eunomia (repo moved)

### DIFF
--- a/site/src/data/skills.ts
+++ b/site/src/data/skills.ts
@@ -182,11 +182,11 @@ export const ECOSYSTEM_CARDS: readonly EcosystemCardSource[] = [
       "https://github.com/CheesecakeLabs/stellar-anchor-skill/blob/main/SKILL.md",
   },
   {
-    title: "PRISM Bounded Agent Treasury",
+    title: "Eunomia Bounded Agent Treasury",
     description:
-      "Give an AI agent a non-custodial, contract-bounded spending account on Stellar with PRISM. Covers treasury deployment with per-payment and rolling daily limits, payee whitelists, time-bound agent session keys, escrow, x402-gated payments, and Groth16/BN254 ZK compliance proofs verified on-chain.",
-    pathLabel: "Bekirerdem/prism",
-    copyValue: "https://github.com/Bekirerdem/prism/blob/main/SKILL.md",
+      "Give an AI agent a non-custodial, contract-bounded spending account on Stellar with Eunomia (formerly PRISM). Covers treasury deployment with per-payment and rolling daily limits, payee whitelists, time-bound agent session keys, escrow, x402-gated payments, and Groth16/BN254 ZK compliance proofs verified on-chain.",
+    pathLabel: "eunomia-finance/eunomia",
+    copyValue: "https://github.com/eunomia-finance/eunomia/blob/main/SKILL.md",
   },
   {
     title: "ROZO Intents",


### PR DESCRIPTION
﻿## What

Updates the PRISM community skill entry: the project has been renamed to **Eunomia** and the repository moved to [`eunomia-finance/eunomia`](https://github.com/eunomia-finance/eunomia) (GitHub redirects the old `Bekirerdem/prism` URLs, but this points the card at the canonical home).

- Title: PRISM Bounded Agent Treasury -> Eunomia Bounded Agent Treasury
- Description: notes the rename ("formerly PRISM") so existing users aren't confused
- pathLabel / copyValue -> eunomia-finance/eunomia

Same product, same SKILL.md (kept up to date at the new location), same maintainer as the original submission (#50).

## Why

We are rebranding ahead of mainnet — the live app now runs at https://eunomia.finance with docs at https://eunomia.finance/docs/.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
