### PR TITLE
Add Sozu Testnet USDC Faucet community skill

### DIFF
--- a/site/src/data/skills.ts
+++ b/site/src/data/skills.ts
@@ -199,7 +199,7 @@ export const ECOSYSTEM_CARDS: readonly EcosystemCardSource[] = [
   {
     title: "Sozu Testnet USDC Faucet",
     description:
-      "Claim Stellar testnet Circle USDC (SAC) with one PoW-gated npx command—the agent-scriptable alternative to the Circle captcha faucet. Omit the address to mint a G… wallet + USDC trustline + claim; existing G… wallets use Stellar Lab for trustlines (no secrets in chat); C… claims directly.",
+      "Claim Circle USDC on Stellar testnet with a PoW-gated CLI, using an existing C…/G… address or a newly generated G… wallet with a USDC trustline.",
     pathLabel: "blessedux/agent-skills",
     copyValue:
       "https://github.com/blessedux/agent-skills/blob/main/sozu-faucet/SKILL.md",

--- a/site/src/data/skills.ts
+++ b/site/src/data/skills.ts
@@ -197,6 +197,14 @@ export const ECOSYSTEM_CARDS: readonly EcosystemCardSource[] = [
       "https://github.com/RozoAI/rozo-intents-skills/blob/main/SKILL.md",
   },
   {
+    title: "Sozu Testnet USDC Faucet",
+    description:
+      "Claim Stellar testnet Circle USDC (SAC) with one npx command (PoW-gated)—the agent-scriptable alternative to the Circle captcha faucet. Covers G… Friendbot + USDC trustline prep, then claim for C…/G… addresses.",
+    pathLabel: "blessedux/agent-skills",
+    copyValue:
+      "https://github.com/blessedux/agent-skills/blob/main/sozu-faucet/SKILL.md",
+  },
+  {
     title: "LumenLoop MCP Connect",
     description:
       "Connect any MCP client (Claude, ChatGPT, Gemini, Cursor) to LumenLoop's free read-only Stellar ecosystem MCP and learn its query tools for directory, content, and SCF data.",

--- a/site/src/data/skills.ts
+++ b/site/src/data/skills.ts
@@ -199,7 +199,7 @@ export const ECOSYSTEM_CARDS: readonly EcosystemCardSource[] = [
   {
     title: "Sozu Testnet USDC Faucet",
     description:
-      "Claim Stellar testnet Circle USDC (SAC) with one npx command (PoW-gated)—the agent-scriptable alternative to the Circle captcha faucet. Covers G… Friendbot + USDC trustline prep, then claim for C…/G… addresses.",
+      "Claim Stellar testnet Circle USDC (SAC) with one PoW-gated npx command—the agent-scriptable alternative to the Circle captcha faucet. Omit the address to mint a G… wallet + USDC trustline + claim; existing G… wallets use Stellar Lab for trustlines (no secrets in chat); C… claims directly.",
     pathLabel: "blessedux/agent-skills",
     copyValue:
       "https://github.com/blessedux/agent-skills/blob/main/sozu-faucet/SKILL.md",


### PR DESCRIPTION
## Summary

- Adds **Sozu Testnet USDC Faucet** to `ECOSYSTEM_CARDS` so it appears on [skills.stellar.org](https://skills.stellar.org/) and in generated `llms.txt`.
- Skill source: https://github.com/blessedux/agent-skills/blob/main/sozu-faucet/SKILL.md
- Install: `npx skills add https://github.com/blessedux/agent-skills --skill sozu-faucet`
- CLI: `npx @sozu/faucet@latest` (**0.2.0+**)

### Why this skill is useful

Nothing in the official or community Stellar skills catalog currently gives an agent a **scriptable** path to claim **testnet Circle USDC (SAC)**.

- **Friendbot** (linked from the standards skill) funds **XLM only** — not USDC.
- The official **agentic-payments** skill’s testnet runbook explicitly calls out the Circle USDC faucet as **web/captcha-only and not scriptable**, then stops there for funding.
- Adjacent skills (ROZO, PRISM, anchors, assets) cover sending, spending, ramps, or trustline *mechanics* — not claiming testnet USDC.

Sozu fills that gap with one PoW-gated command:

```bash
npx @sozu/faucet@latest claim              # new G… + Friendbot + USDC trustline + claim
npx @sozu/faucet@latest claim <C_OR_G>     # fund an existing wallet
```

- **C…** smart accounts claim directly (no trustline).
- **Existing G…** without a trustline → CLI returns `trustline_required` + Stellar Lab `helpUrl` (user signs there — agents never ask for secrets in chat).
- **No address** → CLI mints a wallet, adds the trustline locally, and claims; `wallet.secret` is printed once in the JSON.

That unblocks agentic test loops for SAC / DeFi / x402 without a human captcha step.

## Test plan

- [x] `pnpm lint:ts` and `pnpm build` succeed in `site/`
- [x] Generated `llms.txt` includes the new ecosystem card
- [x] Skill on `blessedux/agent-skills` main documents bare claim + Lab trustlines (`author: blessedux`)
- [x] Prod smoke: `npx @sozu/faucet@0.2.0 claim` → 20 USDC; G without trustline → Lab link
- [ ] Confirm card renders under Community skills on the preview deploy
- [ ] Optional: `npx skills add https://github.com/blessedux/agent-skills --skill sozu-faucet` then bare `claim`