### PR TITLE
Add stellar-agent-search to community skills and AI & MCP Tools

### DIFF
--- a/site/src/data/skills.ts
+++ b/site/src/data/skills.ts
@@ -287,7 +287,7 @@ export const ECOSYSTEM_CARDS: readonly EcosystemCardSource[] = [
   {
     title: "Stellar Agent Search",
     description:
-      "Register a read-only, keyless stdio MCP server (stellar-agent-search) that lets an AI agent discover, rank, and vet on-chain Stellar 8004 agents on mainnet via natural-language queries. Covers find/rank/profile tools, declared-vs-verified reputation boundaries, self-declared x402/MPP service candidates, and the /prepare-x402-call workflow that stops before signing.",
+      "Read-only, keyless MCP server that lets an AI agent discover, rank, and vet on-chain Stellar 8004 agents on mainnet by natural-language query, stopping before any payment or signing.",
     pathLabel: "berkingurcan/stellar-agent-search",
     copyValue:
       "https://github.com/berkingurcan/stellar-agent-search/blob/main/skills/mcp/SKILL.md",

--- a/site/src/data/skills.ts
+++ b/site/src/data/skills.ts
@@ -284,4 +284,12 @@ export const ECOSYSTEM_CARDS: readonly EcosystemCardSource[] = [
     pathLabel: "stellarlight.xyz/scout",
     copyValue: "https://stellarlight.xyz/skills/stellar-scout.md",
   },
+  {
+    title: "Stellar Agent Search",
+    description:
+      "Register a read-only, keyless stdio MCP server (stellar-agent-search) that lets an AI agent discover, rank, and vet on-chain Stellar 8004 agents on mainnet via natural-language queries. Covers find/rank/profile tools, declared-vs-verified reputation boundaries, self-declared x402/MPP service candidates, and the /prepare-x402-call workflow that stops before signing.",
+    pathLabel: "berkingurcan/stellar-agent-search",
+    copyValue:
+      "https://github.com/berkingurcan/stellar-agent-search/blob/main/skills/mcp/SKILL.md",
+  },
 ] as const;

--- a/skills/standards/SKILL.md
+++ b/skills/standards/SKILL.md
@@ -350,14 +350,6 @@ Remote Model Context Protocol (MCP) server for AI agents. Searches Stellar docs 
 - **Connect (Claude Code)**: `claude mcp add --transport http stellar-raven "https://raven.stellar.buzz/mcp"`
 - **Tools**: `search`, `execute`
 
-#### Stellar Agent Search
-Read-only, keyless stdio Model Context Protocol (MCP) server (npm `stellar-agent-search`) that lets an AI agent discover, rank, and vet on-chain [Stellar 8004](https://stellar8004.com) agents on Stellar mainnet, then prepare an x402 (USDC) call without signing. Reputation values stay declared; a bounded Reputation-contract reachability probe degrades closed rather than manufacturing a match. Remote `/mcp` endpoint not live yet — use stdio.
-- **GitHub**: https://github.com/berkingurcan/stellar-agent-search
-- **npm**: https://www.npmjs.com/package/stellar-agent-search
-- **Connect (Claude Code)**: `npx -y stellar-agent-search@0.1.0 setup --client claude --scope user --handshake`
-- **Tools**: `find_agent`, `rank_agent`, `get_agent_profile`, `list_services`, plus 9 complete-core tools
-- **Companion skills**: `trionlabs/stellar-8004` (`8004stellar` reads, `x402stellar` writes)
-
 ## Oracles
 
 #### Reflector Network

--- a/skills/standards/SKILL.md
+++ b/skills/standards/SKILL.md
@@ -350,6 +350,14 @@ Remote Model Context Protocol (MCP) server for AI agents. Searches Stellar docs 
 - **Connect (Claude Code)**: `claude mcp add --transport http stellar-raven "https://raven.stellar.buzz/mcp"`
 - **Tools**: `search`, `execute`
 
+#### Stellar Agent Search
+Read-only, keyless stdio Model Context Protocol (MCP) server (npm `stellar-agent-search`) that lets an AI agent discover, rank, and vet on-chain [Stellar 8004](https://stellar8004.com) agents on Stellar mainnet, then prepare an x402 (USDC) call without signing. Reputation values stay declared; a bounded Reputation-contract reachability probe degrades closed rather than manufacturing a match. Remote `/mcp` endpoint not live yet — use stdio.
+- **GitHub**: https://github.com/berkingurcan/stellar-agent-search
+- **npm**: https://www.npmjs.com/package/stellar-agent-search
+- **Connect (Claude Code)**: `npx -y stellar-agent-search@0.1.0 setup --client claude --scope user --handshake`
+- **Tools**: `find_agent`, `rank_agent`, `get_agent_profile`, `list_services`, plus 9 complete-core tools
+- **Companion skills**: `trionlabs/stellar-8004` (`8004stellar` reads, `x402stellar` writes)
+
 ## Oracles
 
 #### Reflector Network


### PR DESCRIPTION
## Summary
- list the **stellar-agent-search** Agent Skill in the Community Skills catalog (`site/src/data/skills.ts`)
- add a parallel entry under **AI & MCP Tools** in `skills/standards/SKILL.md`, next to Raven
- point both at the publicly maintained `skills/mcp/SKILL.md`

stellar-agent-search is a read-only, keyless stdio MCP server (npm `stellar-agent-search@0.1.0`) over the canonical on-chain Stellar 8004 agent registry. It lets an AI agent discover, rank, and vet on-chain agents on Stellar mainnet via natural-language queries, with a versioned declared-evidence ranking policy and a fail-closed Reputation-contract reachability probe that verifies no reputation fields today. The `/prepare-x402-call` prompt lays out the x402 (USDC) flow and stops before signing — the server holds no keys.

## Skill source
- Skill: https://github.com/berkingurcan/stellar-agent-search/blob/main/skills/mcp/SKILL.md
- Repo: https://github.com/berkingurcan/stellar-agent-search
- npm: https://www.npmjs.com/package/stellar-agent-search
- Mainnet proof (x402 payment + feedback txs): linked in the upstream README

## Validation
- Agent Skills `skills-ref validate` (agentskills/agentskills): passed — `Valid skill: mcp`
- `site/`: `pnpm install` + `pnpm lint` + `pnpm lint:ts` + `pnpm build` → green (12/12 static pages generated)
- new card renders in the generated `llms.txt` (build artifact, confirmed)
- skill URL is publicly readable