### PR TITLE
Add ROZO Checkout and MPP Discover ecosystem skill cards

### DIFF
--- a/site/src/data/skills.ts
+++ b/site/src/data/skills.ts
@@ -284,4 +284,22 @@ export const ECOSYSTEM_CARDS: readonly EcosystemCardSource[] = [
     pathLabel: "stellarlight.xyz/scout",
     copyValue: "https://stellarlight.xyz/skills/stellar-scout.md",
   },
+  {
+    title: "ROZO Checkout",
+    description:
+      "Pay for AI services with Stellar USDC. Settles an OpenRouter Coinbase Payment Link — which cannot take Stellar directly — through a one-time deposit order and automatic invoice settlement, with CLI progress, expiry countdown, and balance checks. More AI services coming.",
+    pathLabel: "RozoAI/rozo-checkout-skill",
+    copyValue:
+      "https://github.com/RozoAI/rozo-checkout-skill/blob/main/SKILL.md",
+    category: "Ecosystem",
+  },
+  {
+    title: "MPP Discover",
+    description:
+      "Find and pay 670+ APIs with Stellar USDC through MPP Router. An agent fetches the live service catalog, picks a service — search, scraping, AI inference, market data — and settles per request. Every verified service is backed by a real paid call with a published Stellar transaction hash.",
+    pathLabel: "mpprouter/stellar-agent-wallet-skill",
+    copyValue:
+      "https://github.com/mpprouter/stellar-agent-wallet-skill/blob/main/skills/discover/SKILL.md",
+    category: "Ecosystem",
+  },
 ] as const;

--- a/site/src/data/skills.ts
+++ b/site/src/data/skills.ts
@@ -296,7 +296,7 @@ export const ECOSYSTEM_CARDS: readonly EcosystemCardSource[] = [
   {
     title: "MPP Discover",
     description:
-      "Find and pay 670+ APIs with Stellar USDC through MPP Router — including OpenAI, Anthropic, DeepSeek, Perplexity, Exa, Firecrawl, and Tavily. An agent fetches the live service catalog, picks a service, and settles per request. Every verified service is backed by a real paid call with a published Stellar transaction hash.",
+      "Find and pay APIs from 90+ services with Stellar USDC through MPP Router — including OpenAI, Anthropic, DeepSeek, Perplexity, Exa, Firecrawl, and Tavily. An agent fetches the live service catalog, picks a service, and settles per request. Every verified service is backed by a real paid call with a published Stellar transaction hash.",
     pathLabel: "mpprouter/stellar-agent-wallet-skill",
     copyValue:
       "https://github.com/mpprouter/stellar-agent-wallet-skill/blob/main/skills/discover/SKILL.md",

--- a/site/src/data/skills.ts
+++ b/site/src/data/skills.ts
@@ -291,7 +291,6 @@ export const ECOSYSTEM_CARDS: readonly EcosystemCardSource[] = [
     pathLabel: "RozoAI/rozo-checkout-skill",
     copyValue:
       "https://github.com/RozoAI/rozo-checkout-skill/blob/main/SKILL.md",
-    category: "Ecosystem",
   },
   {
     title: "MPP Discover",
@@ -300,6 +299,5 @@ export const ECOSYSTEM_CARDS: readonly EcosystemCardSource[] = [
     pathLabel: "mpprouter/stellar-agent-wallet-skill",
     copyValue:
       "https://github.com/mpprouter/stellar-agent-wallet-skill/blob/main/skills/discover/SKILL.md",
-    category: "Ecosystem",
   },
 ] as const;

--- a/site/src/data/skills.ts
+++ b/site/src/data/skills.ts
@@ -287,7 +287,7 @@ export const ECOSYSTEM_CARDS: readonly EcosystemCardSource[] = [
   {
     title: "ROZO Checkout",
     description:
-      "Pay for AI services with Stellar USDC. Settles an OpenRouter Coinbase Payment Link — which cannot take Stellar directly — through a one-time deposit order and automatic invoice settlement, with CLI progress, expiry countdown, and balance checks. More AI services coming.",
+      "Pay for AI services with Stellar USDC — e.g. OpenRouter and Venice.ai, which cannot take Stellar directly — through a one-time deposit order and automatic invoice settlement. More AI services coming.",
     pathLabel: "RozoAI/rozo-checkout-skill",
     copyValue:
       "https://github.com/RozoAI/rozo-checkout-skill/blob/main/SKILL.md",
@@ -296,7 +296,7 @@ export const ECOSYSTEM_CARDS: readonly EcosystemCardSource[] = [
   {
     title: "MPP Discover",
     description:
-      "Find and pay 670+ APIs with Stellar USDC through MPP Router. An agent fetches the live service catalog, picks a service — search, scraping, AI inference, market data — and settles per request. Every verified service is backed by a real paid call with a published Stellar transaction hash.",
+      "Find and pay 670+ APIs with Stellar USDC through MPP Router — including OpenAI, Anthropic, DeepSeek, Perplexity, Exa, Firecrawl, and Tavily. An agent fetches the live service catalog, picks a service, and settles per request. Every verified service is backed by a real paid call with a published Stellar transaction hash.",
     pathLabel: "mpprouter/stellar-agent-wallet-skill",
     copyValue:
       "https://github.com/mpprouter/stellar-agent-wallet-skill/blob/main/skills/discover/SKILL.md",


### PR DESCRIPTION
##Summary
Adds two community skill cards to `ECOSYSTEM_CARDS` in `site/src/data/skills.ts`:

## ROZO Checkout
ROZO Checkout (`RozoAI/rozo-checkout-skill`) — pay for AI services with Stellar USDC — e.g. OpenRouter and Venice.ai, which cannot take Stellar directly — through a one-time deposit order with automatic invoice settlement. `npx skills add RozoAI/rozo-checkout-skill` verified working.

Demo Video: [Pay OpenRouter with Stellar Agent](https://youtu.be/aPJKHoV3H70)


## MPP Discover
MPP Discover (`mpprouter/stellar-agent-wallet-skill` → `skills/discover/SKILL.md`) — find and pay APIs from 90+ services with Stellar USDC through MPP Router, including OpenAI, Anthropic, DeepSeek, Perplexity, Exa, Firecrawl, and Tavily. An agent fetches the live service catalog, picks a service, and settles per request. Every verified service is backed by a real paid call with a published Stellar transaction hash ([audit trail](https://github.com/mpprouter/rozo-mpprouter/blob/main/docs/verified-runs.json)).

Demo Video: https://youtu.be/6N6VGQ1YZxQ


Both follow the security posture from #54's review: mainnet payments prompt by default, unattended signing is opt-in with a $5 hard cap.

## Verification
- One-file change, same card format as existing entries; syntax checked.
- Service count is verifiable against the live catalog: `GET https://apiserver.mpprouter.dev/v1/services/catalog` (90+ providers).
