### PR TITLE
Add ROZO Checkout to ECOSYSTEM_CARDS

### DIFF
--- a/site/src/data/skills.ts
+++ b/site/src/data/skills.ts
@@ -198,6 +198,14 @@ export const ECOSYSTEM_CARDS: readonly EcosystemCardSource[] = [
     copyValue: "https://github.com/eunomia-finance/eunomia/blob/main/SKILL.md",
   },
   {
+    title: "ROZO Checkout",
+    description:
+      "Pay for AI services with Stellar USDC. Settles an OpenRouter Coinbase Payment Link — which cannot take Stellar directly — through a one-time deposit order and automatic invoice settlement, with CLI progress, expiry countdown, and balance checks. More AI services coming.",
+    pathLabel: "RozoAI/rozo-checkout-skill",
+    copyValue:
+      "https://github.com/RozoAI/rozo-checkout-skill/blob/main/SKILL.md",
+  },
+  {
     title: "ROZO Intents",
     description:
       "Send USDC and USDT across Stellar, Ethereum, Arbitrum, Base, BSC, Polygon, and Solana using natural language. Covers cross-chain bridging, wallet detection, fee estimation, tiered confirmation logic, and QR code payment parsing inside Claude Code.",


### PR DESCRIPTION
Adds a community card for **ROZO Checkout** ([RozoAI/rozo-checkout-skill](https://github.com/RozoAI/rozo-checkout-skill)) — pay for AI services (OpenRouter today) with Stellar USDC. A Coinbase Payment Link cannot take Stellar directly; the skill creates a one-time deposit order and a funder settles the invoice, with CLI progress, expiry countdown and balance checks.

Same team as the existing ROZO Intents card. The repo ships SKILL.md at the linked path, installs via `npx skills add RozoAI/rozo-checkout-skill`, and has a public security-audit trail (ClawHub) with recent hardening (no child_process, declared permissions, keyless default path).