### PR TITLE
Add Soroban Common Mistakes to community skills

### DIFF
--- a/site/src/data/skills.ts
+++ b/site/src/data/skills.ts
@@ -319,7 +319,7 @@ export const ECOSYSTEM_CARDS: readonly EcosystemCardSource[] = [
   {
     title: "Soroban Common Mistakes",
     description:
-      "Review Soroban contracts against 22 recurring security mistakes before shipping: missing authorization, storage and TTL pitfalls, arithmetic overflow, and unsafe panic handling. Ships with a reviewable checklist, a PR template, and a Scout CI workflow. Available in English and Spanish.",
+      "Review Soroban contracts against 23 recurring security mistakes before shipping: missing authorization, storage and TTL pitfalls, arithmetic overflow, and unsafe panic handling. Ships with a reviewable checklist, a PR template, and a Scout CI workflow. Available in English and Spanish.",
     pathLabel: "mariaelisaaraya/stellar-security-guide",
     copyValue:
       "https://github.com/mariaelisaaraya/stellar-security-guide/blob/main/skills/soroban-common-mistakes/SKILL.md",

--- a/site/src/data/skills.ts
+++ b/site/src/data/skills.ts
@@ -308,4 +308,12 @@ export const ECOSYSTEM_CARDS: readonly EcosystemCardSource[] = [
     copyValue:
       "https://github.com/berkingurcan/stellar-agent-search/blob/main/skills/mcp/SKILL.md",
   },
+  {
+    title: "Soroban Common Mistakes",
+    description:
+      "Review Soroban contracts against 22 recurring security mistakes before shipping: missing authorization, storage and TTL pitfalls, arithmetic overflow, and unsafe panic handling. Ships with a reviewable checklist, a PR template, and a Scout CI workflow. Available in English and Spanish.",
+    pathLabel: "mariaelisaaraya/stellar-security-guide",
+    copyValue:
+      "https://github.com/mariaelisaaraya/stellar-security-guide/blob/main/skills/soroban-common-mistakes/SKILL.md",
+  },
 ] as const;


### PR DESCRIPTION
Adds the `soroban-common-mistakes` skill to the community skills directory. It reviews Soroban contracts against 23 common security mistake patterns, cross-checked against the official Stellar docs.

Part of a broader open security toolkit for LATAM builders, with the full guide available in both English and Spanish.

@kaankacar following up on your suggestion to submit this here = )