### PR TITLE
Add Caatinga skill to community ecosystem cards

### DIFF
--- a/site/src/data/skills.ts
+++ b/site/src/data/skills.ts
@@ -208,7 +208,7 @@ export const ECOSYSTEM_CARDS: readonly EcosystemCardSource[] = [
   {
     title: "Caatinga",
     description:
-      "Deploy and manage Soroban contract lifecycles with the Caatinga CLI (ctg). Covers the init → doctor → build → deploy → generate → invoke workflow, the multi-contract Deployment Graph, versioned caatinga.artifacts.json as the source of truth for contract IDs, generated TypeScript bindings, and wallet adapters (Freighter, Stellar Wallets Kit) — with hard rules against raw secret keys on the command line and hand-edited artifacts or bindings."
+      "Deploy and manage Soroban contract lifecycles with the Caatinga CLI (ctg). Covers the init → doctor → build → deploy → generate → invoke workflow, the multi-contract Deployment Graph, versioned caatinga.artifacts.json as the source of truth for contract IDs, generated TypeScript bindings, and wallet adapters (Freighter, Stellar Wallets Kit) — with hard rules against raw secret keys on the command line and hand-edited artifacts or bindings.",
     pathLabel: "Dione-b/caatinga-skill",
     copyValue:
       "https://github.com/Dione-b/caatinga-skill/blob/master/skills/caatinga/SKILL.md",

--- a/site/src/data/skills.ts
+++ b/site/src/data/skills.ts
@@ -208,7 +208,7 @@ export const ECOSYSTEM_CARDS: readonly EcosystemCardSource[] = [
   {
     title: "Caatinga",
     description:
-      "Deploy and manage Soroban contract lifecycles with the Caatinga CLI (`ctg`). Covers the init → doctor → build → deploy → generate → invoke workflow, the multi-contract Deployment Graph, versioned `caatinga.artifacts.json` as the source of truth for contract IDs, generated TypeScript bindings, and wallet adapters (Freighter, Stellar Wallets Kit) — with hard rules against raw secret keys on the command line and hand-edited artifacts or bindings.",
+      "Deploy and manage Soroban contract lifecycles with the Caatinga CLI (ctg). Covers the init → doctor → build → deploy → generate → invoke workflow, the multi-contract Deployment Graph, versioned caatinga.artifacts.json as the source of truth for contract IDs, generated TypeScript bindings, and wallet adapters (Freighter, Stellar Wallets Kit) — with hard rules against raw secret keys on the command line and hand-edited artifacts or bindings."
     pathLabel: "Dione-b/caatinga-skill",
     copyValue:
       "https://github.com/Dione-b/caatinga-skill/blob/master/skills/caatinga/SKILL.md",

--- a/site/src/data/skills.ts
+++ b/site/src/data/skills.ts
@@ -206,6 +206,14 @@ export const ECOSYSTEM_CARDS: readonly EcosystemCardSource[] = [
       "https://github.com/RozoAI/rozo-intents-skills/blob/main/SKILL.md",
   },
   {
+    title: "Caatinga",
+    description:
+      "Deploy and manage Soroban contract lifecycles with the Caatinga CLI (`ctg`). Covers the init → doctor → build → deploy → generate → invoke workflow, the multi-contract Deployment Graph, versioned `caatinga.artifacts.json` as the source of truth for contract IDs, generated TypeScript bindings, and wallet adapters (Freighter, Stellar Wallets Kit) — with hard rules against raw secret keys on the command line and hand-edited artifacts or bindings.",
+    pathLabel: "Dione-b/caatinga-skill",
+    copyValue:
+      "https://github.com/Dione-b/caatinga-skill/blob/master/skills/caatinga/SKILL.md",
+  },
+  {
     title: "Sozu Testnet USDC Faucet",
     description:
       "Claim Circle USDC on Stellar testnet with a PoW-gated CLI, using an existing C…/G… address or a newly generated G… wallet with a USDC trustline.",


### PR DESCRIPTION
## Summary

- Adds **Caatinga** to `ECOSYSTEM_CARDS` so it appears on [skills.stellar.org](https://skills.stellar.org/) and in generated `llms.txt`.
- Skill source: https://github.com/Dione-b/caatinga-skill/blob/master/skills/caatinga/SKILL.md
- Install (Claude Code plugin marketplace):
  ```
  /plugin marketplace add Dione-b/caatinga-skill
  /plugin install caatinga-skill@caatinga-skill
  ```
- CLI: `@caatinga/cli` (`ctg` command)

### Why this skill is useful

The catalog's `smart-contracts` skill covers writing and deploying Soroban contracts with the Stellar CLI directly, but doesn't address the deployment-orchestration layer teams need once a project has **multiple interdependent contracts** and generated frontend bindings to keep in sync.

Caatinga fills that gap for the `ctg` workflow:

- **Deployment Graph** — contracts declare `dependsOn` in `caatinga.config.ts`; Caatinga topologically sorts and deploys them in the correct order instead of requiring manual sequencing.
- **Versioned artifacts as source of truth** — `caatinga.artifacts.json` tracks contract IDs per network, replacing manual `.env` copy/paste that drifts on redeploy.
- **Generated TypeScript bindings** — `ctg generate` keeps frontend clients in sync with what's actually deployed.
- **Credential hygiene** — the skill actively steers agents away from passing raw secret keys via `--source` and from hand-editing generated artifacts/bindings, both common failure modes when an agent falls back to raw `stellar` CLI commands in a Caatinga-managed repo.

This gives agents working in `ctg`-based repos (signaled by `caatinga.config.ts` / `caatinga.artifacts.json` / `CAATINGA_*` env vars) opinionated, project-aware guidance instead of generic Stellar CLI advice that would bypass Caatinga's invariants.

## Test plan

- [x] `node --experimental-strip-types scripts/generate-llms-txt.mjs` succeeds and the generated `llms.txt` includes the new ecosystem card
- [x] Skill on `Dione-b/caatinga-skill` documents the `ctg` workflow, hard rules, and install steps
- [ ] Confirm card renders under Community skills on the preview deploy
- [ ] Optional: install the plugin via `/plugin marketplace add Dione-b/caatinga-skill` and try a Caatinga-related prompt