### PR TITLE
Add an open-link button to skill cards and retire generic Soroban wording

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -123,7 +123,7 @@ the repo root, then append to `SKILL_CARD_SOURCES` in
 ```ts
 {
   source: "skills/<your-skill>/SKILL.md",
-  category: "Soroban", // any FilterType value
+  category: "Smart Contracts", // any FilterType value
   // Optional overrides — default to the upstream SKILL.md's first H1
   // (title) and frontmatter `description`.
   title: "Your Skill Title",

--- a/site/src/app/_components/SkillCard.tsx
+++ b/site/src/app/_components/SkillCard.tsx
@@ -28,6 +28,10 @@ export const SkillCard = ({
   headingLevel = 2,
 }: SkillCardProps) => {
   const Heading = headingLevel === 3 ? "h3" : "h2";
+  // Ecosystem cards copy the same URL the header already links to, so the
+  // open-in-new-tab chip would be a second link to one destination. Skill
+  // cards copy the mirrored markdown URL, which nothing else links to.
+  const showOpenLink = copyValue !== sourceUrl;
   return (
     <Card>
       <div className="SkillsCard">
@@ -46,11 +50,24 @@ export const SkillCard = ({
 
         <p className="SkillsCard__description">{description}</p>
 
-        <CopyButton
-          variant="path"
-          value={copyValue}
-          displayValue={pathLabel}
-        />
+        <div className="SkillsCard__pathRow">
+          <CopyButton
+            variant="path"
+            value={copyValue}
+            displayValue={pathLabel}
+          />
+          {showOpenLink && (
+            <a
+              href={copyValue}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label={`Open ${pathLabel} in a new tab`}
+              className="SkillsCard__pathButton SkillsCard__openLink"
+            >
+              <LinkExternal01Icon />
+            </a>
+          )}
+        </div>
       </div>
     </Card>
   );

--- a/site/src/app/styles.scss
+++ b/site/src/app/styles.scss
@@ -484,6 +484,33 @@ h2.SkillsCard__title {
   color: var(--sds-clr-gray-12);
 }
 
+// Copy pill plus the "open in a new tab" chip that sits beside it on a
+// skill card. Wraps on narrow cards so the chip drops under a long path
+// instead of squeezing it.
+.SkillsCard__pathRow {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: pxToRem(6px);
+  min-width: 0;
+
+  .SkillsCard__pathWrapper {
+    min-width: 0;
+  }
+}
+
+// Anchor styled as a path chip: same background and hover treatment as
+// .SkillsCard__pathButton, minus the link underline.
+.SkillsCard__openLink {
+  text-decoration: none;
+  flex-shrink: 0;
+
+  &:focus-visible {
+    outline: 2px solid var(--sds-clr-lilac-11);
+    outline-offset: 2px;
+  }
+}
+
 .SkillsCard__header {
   display: flex;
   align-items: center;

--- a/skills/cross-chain/SKILL.md
+++ b/skills/cross-chain/SKILL.md
@@ -22,14 +22,14 @@ Rules of thumb: if the asset is USDC and both ends are CCTP chains, CCTP is the 
 
 - Bridging USDC between Stellar and Ethereum, Base, Arbitrum, Solana, or another CCTP-supported chain
 - Receiving bridged USDC into a Stellar account or contract (and not bricking the funds — see the forwarder warning below)
-- Writing a Soroban contract that sends messages to or receives messages from contracts on other chains
+- Writing a Stellar smart contract that sends messages to or receives messages from contracts on other chains
 - Deploying an interchain token, or connecting an existing Stellar asset to other ecosystems
 - Adding a "deposit from any chain" or cross-chain swap flow to a wallet or dapp
 
 ## Related skills
 
 - Trustlines, SAC deployment, asset anatomy → `../assets/SKILL.md`
-- Writing the Soroban contracts that send/receive messages → `../smart-contracts/SKILL.md`
+- Writing the Stellar smart contracts that send/receive messages → `../smart-contracts/SKILL.md`
 - Frontend transaction building, Freighter signing, RPC submission → `../dapp/SKILL.md`
 - Watching for the destination-side mint or contract events → `../data/SKILL.md`
 - Paying AI agents (x402/MPP) rather than bridging → `../agentic-payments/SKILL.md`
@@ -39,7 +39,7 @@ Rules of thumb: if the asset is USDC and both ends are CCTP chains, CCTP is the 
 These bite regardless of which rail you pick. Each companion file adds rail-specific ones.
 
 1. **Address formats do not translate.** Stellar addresses are `strkey` strings (`G…` accounts, `C…` contracts, `M…` muxed); EVM uses 20-byte hex; Solana uses base58. Every rail defines its own encoding for foreign addresses (CCTP: raw 32-byte payloads; Axelar: strings + bytes payloads). Never paste an address from one chain into a field meant for another — encode it the way the rail specifies, and validate with the SDK (`StrKey.isValidEd25519PublicKey` / `isValidContract`) before encoding.
-2. **Decimals differ.** Classic Stellar assets and their SACs use 7 decimals, but other Soroban token contracts (ITS-deployed tokens included) declare their own — call `decimals()` instead of assuming. USDC is 6 on every supported chain except Stellar (which uses 7); EVM tokens are commonly 18; CCTP messages are always 6-decimal. Convert at every boundary and test with amounts that exercise the last digit (see the worked decimal examples in [cctp.md](cctp.md#usdc-precision-7-decimals-vs-6)).
+2. **Decimals differ.** Classic Stellar assets and their SACs use 7 decimals, but other Stellar token contracts (ITS-deployed tokens included) declare their own — call `decimals()` instead of assuming. USDC is 6 on every supported chain except Stellar (which uses 7); EVM tokens are commonly 18; CCTP messages are always 6-decimal. Convert at every boundary and test with amounts that exercise the last digit (see the worked decimal examples in [cctp.md](cctp.md#usdc-precision-7-decimals-vs-6)).
 3. **Classic Stellar recipients need a trustline first.** A `G…` account cannot receive an issued asset (USDC included) without a trustline to that asset. Bridged funds destined for an account without one will not land. Check and provision before starting the transfer — see `../assets/SKILL.md`.
 4. **Cross-chain is asynchronous.** Every rail has a wait: CCTP waits for finality plus Circle's attestation (seconds to ~15 minutes depending on chain and finality threshold), Axelar waits for validator confirmation, intents wait for a market maker. Build UIs and agents around polling a status, never around "submit and assume".
 5. **Testnet first, always.** Every rail here except NEAR Intents has a testnet deployment (intents are filled by real market makers — mainnet only; rehearse with dry quotes and a dust-sized swap instead). Do the full round-trip on testnet before touching mainnet — cross-chain mistakes are frequently unrecoverable by design (burns are final, and some misencodings permanently strand funds).

--- a/skills/cross-chain/axelar.md
+++ b/skills/cross-chain/axelar.md
@@ -2,10 +2,10 @@
 
 [Axelar](https://docs.axelar.dev/) connects Stellar to EVM chains and the wider Axelar ecosystem through its amplifier stack. Two products matter here:
 
-- **GMP (General Message Passing)** — a Soroban contract sends arbitrary payloads to a contract on another chain, or receives and executes payloads from one.
+- **GMP (General Message Passing)** — a Stellar smart contract sends arbitrary payloads to a contract on another chain, or receives and executes payloads from one.
 - **ITS (Interchain Token Service)** — tokens that exist on multiple chains: mint new ones, or connect an existing Stellar token.
 
-Both are live on Stellar testnet and mainnet. The Stellar contracts are Rust/Soroban and live in [axelar-amplifier-stellar](https://github.com/axelarnetwork/axelar-amplifier-stellar) — `stellar-axelar-gateway`, `stellar-axelar-gas-service`, and the ITS contracts. Every signature in this file is checked against those sources, which occasionally run ahead of the docs site; when they disagree, the source wins.
+Both are live on Stellar testnet and mainnet. The Stellar contracts are Rust smart contracts and live in [axelar-amplifier-stellar](https://github.com/axelarnetwork/axelar-amplifier-stellar) — `stellar-axelar-gateway`, `stellar-axelar-gas-service`, and the ITS contracts. Every signature in this file is checked against those sources, which occasionally run ahead of the docs site; when they disagree, the source wins.
 
 > **Addresses and chain names:** resolve the current Gateway, Gas Service, and ITS addresses from [`axelar-chains-config/info/mainnet.json`](https://github.com/axelarnetwork/axelar-contract-deployments/blob/main/axelar-chains-config/info/mainnet.json) / [`testnet.json`](https://github.com/axelarnetwork/axelar-contract-deployments/blob/main/axelar-chains-config/info/testnet.json) in the axelar-contract-deployments repo — the [docs directory](https://docs.axelar.dev/resources/contract-addresses/mainnet/) is built from it but doesn't always render every chain. Chain **names** are deployment-versioned too: the same file's `axelarId` is the exact string `destination_chain` wants (Stellar is `stellar` on mainnet but currently `stellar-2026-q1-2` on testnet). Don't hardcode either from any tutorial, including this one.
 
@@ -103,7 +103,7 @@ Axelar's [Stellar GMP guide](https://docs.axelar.dev/dev/general-message-passing
 
 ## ITS: tokens on multiple chains
 
-ITS on Stellar operates in **hub mode**: token messages route through Axelar's ITS Hub rather than chain-to-chain. Components: the `InterchainTokenService` contract (coordination), a `TokenManager` per token (mint/burn/lock), and `InterchainToken` (a Stellar token interface implementation — meaning ITS-deployed tokens are Soroban contracts, addressable like any `C…` token).
+ITS on Stellar operates in **hub mode**: token messages route through Axelar's ITS Hub rather than chain-to-chain. Components: the `InterchainTokenService` contract (coordination), a `TokenManager` per token (mint/burn/lock), and `InterchainToken` (a Stellar token interface implementation — meaning ITS-deployed tokens are Stellar smart contracts, addressable like any `C…` token).
 
 **Mint a new multichain token** — deploy locally, then extend it to each destination chain (each remote deployment pays its own gas):
 
@@ -158,7 +158,7 @@ fn flow_in_amount(env: &Env, token_id: BytesN<32>) -> i128;
 ## ITS pitfalls
 
 - **`token_id` is the identity, not the address.** The same token has different contract addresses per chain but one `BytesN<32>` token id — persist the id, derive addresses from it.
-- **Decimals don't auto-reconcile across ecosystems.** Classic-asset SACs are 7-decimal, but a canonical registration accepts any Soroban token, and ITS tokens carry whatever `TokenMetadata` declared — read `decimals()` from the token instead of assuming 7, and think through amount scaling before wiring UIs to EVM counterparts (test a dust-sized transfer first).
+- **Decimals don't auto-reconcile across ecosystems.** Classic-asset SACs are 7-decimal, but a canonical registration accepts any Stellar token contract, and ITS tokens carry whatever `TokenMetadata` declared — read `decimals()` from the token instead of assuming 7, and think through amount scaling before wiring UIs to EVM counterparts (test a dust-sized transfer first).
 - **Remote deployments and transfers both prepay gas** via `gas_token` — budget one gas payment per destination chain, not one total.
 - **Flow limits fail closed.** A transfer that would exceed the window's limit is rejected, not queued — surface that error distinctly from "bridge is broken".
 

--- a/skills/cross-chain/cctp.md
+++ b/skills/cross-chain/cctp.md
@@ -12,7 +12,7 @@ Read this file top to bottom before writing any code: CCTP on Stellar has one mi
 
 ## Contracts and addresses
 
-Stellar CCTP runs on three Soroban contracts ([Circle's contract reference](https://developers.circle.com/cctp/references/stellar-contracts) is canonical):
+Stellar CCTP runs on three Stellar smart contracts ([Circle's contract reference](https://developers.circle.com/cctp/references/stellar-contracts) is canonical):
 
 | Contract | Role |
 |---|---|
@@ -107,7 +107,7 @@ Practical consequences: pass 7-decimal subunits (`i128`) to Stellar-side calls a
 Two Stellar transactions in the plain flow — an allowance, then the burn — because `TokenMessengerMinter` pulls funds via `transfer_from`:
 
 1. `approve` the USDC SAC with `TokenMessengerMinter` as spender. Most basic version: approve exactly the transfer amount, with a short `live_until_ledger` (current ledger + ~100 ≈ 8 minutes) so nothing lingers. If an existing allowance already covers the amount (`allowance(from, spender)`), skip this step — or collapse approve + burn into one transaction with the wrapper below.
-2. Call `deposit_for_burn`. Verified argument order (Soroban):
+2. Call `deposit_for_burn`. Verified argument order (Stellar):
 
 ```typescript
 import { Address, Contract, TransactionBuilder, nativeToScVal, BASE_FEE } from "@stellar/stellar-sdk";
@@ -148,7 +148,7 @@ Destination-side reference: CCTP V2 uses the **same contract addresses on every 
 
 Pass Iris's `message` and `attestation` hex to `receiveMessage` verbatim. Domain IDs are Circle-assigned — Ethereum 0, Solana 5, Base 6, Arc 26, Stellar 27; the full table is in [supported chains and domains](https://developers.circle.com/cctp/concepts/supported-chains-and-domains) (a mainnet listing covers its official testnet too).
 
-**One-signature variant.** The two-transaction dance (approve, then burn) collapses into one Soroban transaction with a ~40-line wrapper contract, because Soroban's auth tree lets a single signature authorize both nested calls. From the [reference demo](https://github.com/ElliotFriend/stellar-cctp-demo) (`contracts/stellar/cctp-wrapper/`), verbatim:
+**One-signature variant.** The two-transaction dance (approve, then burn) collapses into one Stellar transaction with a ~40-line wrapper contract, because the contract auth tree lets a single signature authorize both nested calls. From the [reference demo](https://github.com/ElliotFriend/stellar-cctp-demo) (`contracts/stellar/cctp-wrapper/`), verbatim:
 
 ```rust
 pub fn approve_and_deposit(
@@ -207,7 +207,7 @@ Worth studying in the source:
 |---|---|
 | Hook-data encoding ("the most important code in the repo" — get it wrong and funds are lost) | `src/lib/evm/cctp.ts` |
 | Stellar-side burns: direct, wrapper, wrapper-with-hook | `src/lib/stellar/cctp.ts` |
-| The one-signature Soroban wrapper | `contracts/stellar/cctp-wrapper/` |
+| The one-signature Stellar wrapper | `contracts/stellar/cctp-wrapper/` |
 | Iris polling with the hash-normalization gotcha | `src/lib/circle/iris.ts` |
 | Chain/domain/address registry | `src/lib/config.ts` |
 | EVM-side UX ladder: 2-tx approve, 1-tx EIP-2612 permit wrapper, 1-click EIP-5792 `wallet_sendCalls` | `src/lib/evm/cctp.ts`, `contracts/evm/cctp-wrapper/` |

--- a/skills/dapp/SKILL.md
+++ b/skills/dapp/SKILL.md
@@ -274,7 +274,7 @@ export async function buildPaymentTx(
 
 ### Smart Contract Invocation (`contract.Client`)
 
-The canonical way to call a Soroban contract from JS is the `contract.Client`, not hand-built `Contract.call` + `assembleTransaction`. The client reads the contract's interface from the network, so each method is callable by name and returns an `AssembledTransaction`. You get a native JS result and don't build ScVals by hand.
+The canonical way to call a Stellar smart contract from JS is the `contract.Client`, not hand-built `Contract.call` + `assembleTransaction`. The client reads the contract's interface from the network, so each method is callable by name and returns an `AssembledTransaction`. You get a native JS result and don't build ScVals by hand.
 
 ```typescript
 import { contract } from "@stellar/stellar-sdk";

--- a/skills/smart-contracts/development.md
+++ b/skills/smart-contracts/development.md
@@ -383,7 +383,7 @@ Worked examples: [soroban-examples](https://github.com/stellar/soroban-examples)
 
 ## Fees and resource limits
 
-Soroban transactions pay an inclusion fee (classic surge-priced mechanic) plus a resource fee based on declared consumption: CPU instructions, ledger reads/writes (entries and bytes), transaction size, events size, and rent. Rent/events are refundable if unused; instructions and I/O are charged as declared — so submitters simulate first to size the declaration, and a transaction that exceeds its declaration fails. If actual state diverges from simulation (concurrent writes), costs can shift — leave headroom.
+Contract transactions pay an inclusion fee (classic surge-priced mechanic) plus a resource fee based on declared consumption: CPU instructions, ledger reads/writes (entries and bytes), transaction size, events size, and rent. Rent/events are refundable if unused; instructions and I/O are charged as declared — so submitters simulate first to size the declaration, and a transaction that exceeds its declaration fails. If actual state diverges from simulation (concurrent writes), costs can shift — leave headroom.
 
 Current mainnet per-transaction ceilings (network-configured, change by validator vote — check the live values on [Stellar Lab's Network Limits page](https://lab.stellar.org/network-limits) or with `stellar network settings --network mainnet`):
 
@@ -438,7 +438,7 @@ Rows are keyed by the text the CLI or the compiler actually prints — search th
 | `alias 'x' is already referencing contract 'C…' on network '…'` | `stellar contract alias add` won't rebind an alias that points somewhere else | Pass `--overwrite`, or pick another alias — note `stellar contract deploy --alias` always overwrites without asking |
 | `Unable to fund account alice on …`, **and the command still exits 0** | Friendbot request failed. The key *was* saved; the account was never created, so the next command fails on a nonexistent account | Retry against the network the error names — `stellar keys fund alice --network testnet` — which exits non-zero and prints the real cause (`funding failed: …`). Friendbot only exists on testnet/futurenet/local — on mainnet, fund from an already-funded account |
 | `invalid argument format` on invoke | Wrong CLI arg syntax | Plain strings for addresses; JSON for complex types |
-| `transaction simulation failed` | Soroban tx not simulated/assembled | Simulate, then `assembleTransaction` before signing |
+| `transaction simulation failed` | Contract tx not simulated/assembled | Simulate, then `assembleTransaction` before signing |
 | Auth fails only in cross-contract flows | Signed auth tree doesn't match actual call path | Rebuild the tree from simulation; re-auth at each layer (see [Authorization](#authorization)) |
 | `tx_bad_auth` | Wrong network passphrase or signer | Match passphrase to network; check signing identity |
 | `tx_bad_seq` | Stale sequence number | Reload the account before building the tx |

--- a/skills/standards/SKILL.md
+++ b/skills/standards/SKILL.md
@@ -146,7 +146,7 @@ Universal liquidity protocol enabling permissionless lending pools.
 - **Integrations**: Meru, Airtm, Lobstr, DeFindex, Beans
 
 #### K2
-Money market on Soroban with a modular router architecture (Aave V3-inspired). Live on mainnet.
+Money market on Stellar with a modular router architecture (Aave V3-inspired). Live on mainnet.
 - **Use Case**: Supply to earn variable interest, borrow against collateral, collateral swaps, flash loans
 - **Website**: https://k2lend.com
 - **Docs**: https://docs.k2lend.com — agent-friendly: every page has a `.md` twin, plus [llms.txt](https://docs.k2lend.com/llms.txt) and a full corpus export at [llms-full.txt](https://docs.k2lend.com/llms-full.txt)


### PR DESCRIPTION
🤖 _Automated message from Kaan's Automated Triage Bot._

Refs #27 (deliberately not "Closes" — this picks off two items from James's list, the rest are editorial calls I'd rather leave to a human).

The first commit adds the open-link button he asked for: each skill card's copy pill now has an anchor beside it pointing at the same markdown URL, `target="_blank"`. Ecosystem cards don't get one, because their copy value is already the URL the card header links to and a second chip would send you to the same place twice. One caveat worth knowing before merge: GitHub Pages serves those files as `text/markdown`, so whether a browser renders the file inline or offers a download is up to the browser, and the site can't set response headers to influence that.

The second commit is the "Soroban" pass. Generic prose about Soroban contracts, transactions, and tokens now says Stellar smart contracts, matching what `smart-contracts/SKILL.md` already states about the retired platform name. Proper nouns stay put: `soroban-sdk`, `SorobanArbitrary`, the SEP-41 and CAP-46 titles, project names like Scout Soroban and Soroban Playground, and the frontmatter descriptions that keep "Soroban" as a trigger word for users who still call it that. Stellar's own docs still use the name in those senses, so a blanket rename would have made things less accurate, not more. The site README also documented `category: "Soroban"`, which isn't a `FilterType` value any more and would fail `tsc` if anyone copied it.

Note on verification: I could not run `pnpm lint`, `lint:ts`, or `build` in my sandbox (no pnpm available), so I'm relying on the preview workflow to check them. Please don't merge until it's green, and the preview URL is the fastest way to eyeball the new chip.
