### PR TITLE
docs: add Nirium to community skills

### DIFF
--- a/site/src/data/skills.ts
+++ b/site/src/data/skills.ts
@@ -347,4 +347,12 @@ export const ECOSYSTEM_CARDS: readonly EcosystemCardSource[] = [
     pathLabel: "payrouteshq/stellartools",
     copyValue: "https://github.com/payrouteshq/stellartools/blob/main/SKILL.md",
   },
+  {
+    title: "Nirium Agentic Payments",
+    description:
+      "Charge AI agents per API call on Stellar with the Nirium toolkit: scaffold a working x402 seller with nirium-cli in one command, charge per route with x402Serve() from the nirium SDK, and read live protocol data, market state, autonomous loop status, execution nodes, through the nirium-mcp server. Live on mainnet since April 2, 2026, the day the x402 Foundation launched.",
+    pathLabel: "nirium-protocol/nirium-sdk",
+    copyValue:
+      "https://github.com/nirium-protocol/nirium-sdk/blob/main/skills/nirium-agentic-payments/SKILL.md",
+  },
 ] as const;

--- a/site/src/data/skills.ts
+++ b/site/src/data/skills.ts
@@ -350,7 +350,7 @@ export const ECOSYSTEM_CARDS: readonly EcosystemCardSource[] = [
   {
     title: "Nirium Agentic Payments",
     description:
-      "Charge AI agents per API call on Stellar with the Nirium toolkit: scaffold a working x402 seller with nirium-cli in one command, charge per route with x402Serve() from the nirium SDK, and read live protocol data, market state, autonomous loop status, execution nodes, through the nirium-mcp server. Live on mainnet since April 2, 2026, the day the x402 Foundation launched.",
+      "Charge AI agents per API call on Stellar with the Nirium toolkit: scaffold a working x402 seller with nirium-cli in one command, charge per route with x402Serve() from the nirium SDK, and read live protocol data, market state, autonomous loop status, and execution nodes through the nirium-mcp server. Live on mainnet since July 9, 2026.",
     pathLabel: "nirium-protocol/nirium-sdk",
     copyValue:
       "https://github.com/nirium-protocol/nirium-sdk/blob/main/skills/nirium-agentic-payments/SKILL.md",


### PR DESCRIPTION
## Summary

Adds Nirium to `ECOSYSTEM_CARDS` in `site/src/data/skills.ts`, per the
community-skills convention in `site/README.md`.

Nirium is an open-source toolkit for x402 agentic payments on Stellar:
a TypeScript/Python SDK, a scaffolding CLI (`nirium-cli`), and an MCP
server (`nirium-mcp`). Live on mainnet since April 2, 2026, the day the
x402 Foundation launched. The skill teaches an agent to:

- scaffold a working x402 seller with `nirium-cli` in one command
- charge per route with `x402Serve()` from the `nirium` SDK
- read live protocol data (market state, autonomous loop status,
  execution nodes) through `nirium-mcp`

The skill itself lives in the project's own repo (not this one, per the
`ECOSYSTEM_CARDS` convention for community skills):
https://github.com/nirium-protocol/nirium-sdk/blob/main/skills/nirium-agentic-payments/SKILL.md

## Test plan

- [x] `pnpm lint:ts` (`tsc --noEmit`) passes
- [x] `pnpm lint` (`next lint`) passes
- [ ] Card renders correctly in `pnpm dev` / the PR preview build

🤖 Generated with [Claude Code](https://claude.com/claude-code)