### PR TITLE
docs: add Contextio SDK to community skills

### DIFF
--- a/site/src/data/skills.ts
+++ b/site/src/data/skills.ts
@@ -347,4 +347,12 @@ export const ECOSYSTEM_CARDS: readonly EcosystemCardSource[] = [
     pathLabel: "payrouteshq/stellartools",
     copyValue: "https://github.com/payrouteshq/stellartools/blob/main/SKILL.md",
   },
+  {
+    title: "Contextio SDK",
+    description:
+      "Integrate contextio-sdk, the typed client for Contextio's non-custodial treasury and payroll API on Stellar. Covers Sign In With Stellar (SEP-53) wallet auth, reading a tenant's treasury/payroll/agent state, triggering an agent proposal, and independently hashing/verifying a Legal Context Protocol (LCP) document.",
+    pathLabel: "Eras256/Contextio",
+    copyValue:
+      "https://github.com/Eras256/Contextio/blob/main/packages/sdk/contextio-sdk-skill.md",
+  },
 ] as const;


### PR DESCRIPTION
## Summary

Adds Contextio SDK to `ECOSYSTEM_CARDS` in `site/src/data/skills.ts`, per
the community-skills convention in `site/README.md`.

`contextio-sdk` is a typed TypeScript client for Contextio's agentic,
non-custodial treasury & payroll API on Stellar. The skill covers only
what the SDK actually exposes as of the current published version
(`0.3.0`), teaching an agent to:

- authenticate with Sign In With Stellar (SEP-53), wallet-agnostic
  (works with Freighter, Stellar Wallets Kit, or any signer)
- read a tenant's treasury, payroll obligations, and agent decision
  history through the typed client
- trigger an agent proposal (optionally executing it), including a
  verified, non-obvious gotcha: a missing Legal Context Protocol
  document doesn't throw on execute, it returns 200 with an
  `executionError` field not present on the typed return value
- independently hash and verify a Legal Context Protocol (LCP) document
  against a hash bound on-chain, without trusting the API's own claim

The skill deliberately does not document treasury/payroll write
endpoints, or Blend/DeFindex integration, since none of that is part of
the SDK's public client surface today, only internal API/worker
responsibilities.

The skill itself lives in the project's own repo (not this one, per the
`ECOSYSTEM_CARDS` convention for community skills):
https://github.com/Eras256/Contextio/blob/main/packages/sdk/contextio-sdk-skill.md

## Test plan

- [x] `pnpm lint:ts` (`tsc --noEmit`) passes
- [x] `pnpm lint` (`next lint`) passes
- [x] Every SDK method, type, status code, and example value referenced
      in the skill was checked against the live source and the live
      npm registry, not just written from memory

🤖 Generated with [Claude Code](https://claude.com/claude-code)