### PR TITLE
docs: reposition Contextio SDK's catalog description around LCP

### DIFF
--- a/site/src/data/skills.ts
+++ b/site/src/data/skills.ts
@@ -358,7 +358,7 @@ export const ECOSYSTEM_CARDS: readonly EcosystemCardSource[] = [
   {
     title: "Contextio SDK",
     description:
-      "Integrate contextio-sdk, the typed client for Contextio's non-custodial treasury and payroll API on Stellar. Covers Sign In With Stellar (SEP-53) wallet auth, reading a tenant's treasury/payroll/agent state, triggering an agent proposal, and independently hashing/verifying a Legal Context Protocol (LCP) document.",
+      "Integrate contextio-sdk: verifiable, non-custodial legal context binding (Legal Context Protocol / LCP) for Stellar treasury and payroll. Covers Sign In With Stellar (SEP-53) wallet auth, reading a tenant's treasury/payroll/agent state, triggering an agent proposal, and independently hashing/verifying an LCP document against an on-chain hash.",
     pathLabel: "Eras256/Contextio",
     copyValue:
       "https://github.com/Eras256/Contextio/blob/main/packages/sdk/contextio-sdk-skill.md",


### PR DESCRIPTION
## Summary

Small follow-up to #98 (merged) — no functional change, just repositions
the `ECOSYSTEM_CARDS` description for Contextio SDK to open on the Legal
Context Protocol (LCP) binding instead of the treasury/payroll pitch.
Same wording change already applied to the skill's own frontmatter
description in the source repo.

Before:
> Integrate contextio-sdk, the typed client for Contextio's non-custodial
> treasury and payroll API on Stellar. Covers Sign In With Stellar
> (SEP-53) wallet auth, reading a tenant's treasury/payroll/agent state,
> triggering an agent proposal, and independently hashing/verifying a
> Legal Context Protocol (LCP) document.

After:
> Integrate contextio-sdk: verifiable, non-custodial legal context
> binding (Legal Context Protocol / LCP) for Stellar treasury and
> payroll. Covers Sign In With Stellar (SEP-53) wallet auth, reading a
> tenant's treasury/payroll/agent state, triggering an agent proposal,
> and independently hashing/verifying an LCP document against an
> on-chain hash.

`pathLabel`/`copyValue` unchanged — still points at the same skill file.

## Test plan

- [x] `pnpm lint:ts` (`tsc --noEmit`) passes
- [x] `pnpm lint` (`next lint`) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)