### PR TITLE
docs: update Contextio SDK copyValue to the renamed SKILL.md path

### DIFF
--- a/site/src/data/skills.ts
+++ b/site/src/data/skills.ts
@@ -361,6 +361,6 @@ export const ECOSYSTEM_CARDS: readonly EcosystemCardSource[] = [
       "Integrate contextio-sdk, the typed client for Contextio's non-custodial treasury and payroll API on Stellar. Covers Sign In With Stellar (SEP-53) wallet auth, reading a tenant's treasury/payroll/agent state, triggering an agent proposal, and independently hashing/verifying a Legal Context Protocol (LCP) document.",
     pathLabel: "Eras256/Contextio",
     copyValue:
-      "https://github.com/Eras256/Contextio/blob/main/packages/sdk/contextio-sdk-skill.md",
+      "https://github.com/Eras256/Contextio/blob/main/packages/sdk/SKILL.md",
   },
 ] as const;


### PR DESCRIPTION
## Summary

The Contextio SDK skill file moved in the source repo, from
`packages/sdk/contextio-sdk-skill.md` to `packages/sdk/SKILL.md` (flat
`SKILL.md` at the package root, matching the filename convention every
other `ECOSYSTEM_CARDS` entry already uses — `.../blob/main/SKILL.md`
or `.../blob/main/skills/<name>/SKILL.md`, never a custom filename).

Updates `copyValue` to match. `title`, `description`, and `pathLabel`
are untouched — this is a pure link fix, kept separate from #101 (still
in review) so the two don't collide.

Old: `https://github.com/Eras256/Contextio/blob/main/packages/sdk/contextio-sdk-skill.md`
New: `https://github.com/Eras256/Contextio/blob/main/packages/sdk/SKILL.md`

Verified the new URL resolves (`200`) before opening this PR, not just
assumed from the rename commit.

## Test plan

- [x] `pnpm lint:ts` (`tsc --noEmit`) passes
- [x] `pnpm lint` (`next lint`) passes
- [x] `curl -o /dev/null -w "%{http_code}" <new copyValue URL>` → `200`

🤖 Generated with [Claude Code](https://claude.com/claude-code)