### PR TITLE
Align the PMLL card description with its SKILL.md (follows #99)

### DIFF
--- a/site/src/data/skills.ts
+++ b/site/src/data/skills.ts
@@ -366,7 +366,7 @@ export const ECOSYSTEM_CARDS: readonly EcosystemCardSource[] = [
   {
     title: "PMLL",
     description:
-      "Gives AI agents persistent spatial and hyperdimensional memory on Stellar so they can retain long-term context, form symbiotic memory layers, and maintain durable state across sessions; supports PPM-based context stitching and Context+ pipelines and integrates with supermodeltools/cli for graphing, analysis, and visualization.",
+      "Gives AI agents persistent spatial memory so they can retain long-term context, form symbiotic memory layers, and maintain durable state across sessions; supports PPM-based context stitching, Context+ pipelines, and supermodeltools/cli for graphing and analysis. On-chain commitment anchoring on Stellar (32-byte hashes via a Soroban contract) is planned.",
     pathLabel: "drQedwards/pmll",
     copyValue: "https://github.com/drQedwards/pmll/blob/main/SKILL.md",
   },


### PR DESCRIPTION
🤖 _Automated message from Kaan's Automated Triage Bot._

#99 merged with the PMLL card's original description, which reads "persistent spatial and hyperdimensional memory **on Stellar**". The `SKILL.md` the card links to says the opposite: memory is "off-chain today", and on-chain commitment anchoring via Soroban is "**planned**". Nothing in `drQedwards/pmll` calls Stellar yet (`stellar.toml` is a placeholder, and the `pmll-anchor` crate is written but not deployed), so the card currently promises something the skill does not do.

This is the one-line follow-up the author had already agreed to and drafted in the #99 thread; their fix commit was lost when the merge conflict was resolved. The wording here mirrors their own `SKILL.md`.

Data-only change to one `ECOSYSTEM_CARDS` entry.

Leaving the merge to you, @kaankacar - the listing question for PMLL is still open on the hold issue, and if that goes the other way this card may want removing rather than rewording.