### PR TITLE
Point the smart wallet kits at their canonical repos and drop the legacy label

### DIFF
--- a/skills/dapp/smart-accounts.md
+++ b/skills/dapp/smart-accounts.md
@@ -4,7 +4,7 @@ Passkey smart wallets with Smart Account Kit and gasless transactions via the Op
 
 ## Smart Accounts (Passkey Wallets)
 
-For passwordless authentication using WebAuthn passkeys, use Smart Account Kit.
+For passwordless authentication using WebAuthn passkeys, use Smart Account Kit. [Passkey Kit](https://github.com/stellar/passkey-kit) is a sibling SDK built on a different authorization model — see [Choosing between the two kits](#choosing-between-the-two-kits) before you commit to one.
 
 ### Installation
 ```bash
@@ -77,7 +77,18 @@ const response = await client.submitSorobanTransaction({
 - **Production**: Self-host via Docker ([GitHub](https://github.com/OpenZeppelin/openzeppelin-relayer))
 - **Stellar docs**: https://developers.stellar.org/docs/tools/openzeppelin-relayer
 
+### Choosing between the two kits
+
+Passkey Kit and Smart Account Kit are sibling SDKs, not successive versions. They use different on-chain authorization models, so they are **not drop-in compatible**. Pick the model that fits your app.
+
+| Kit | Authorization model | Reach for it when |
+|-----|--------------------|-------------------|
+| [smart-account-kit](https://github.com/stellar/smart-account-kit) | OpenZeppelin context rules + an auth digest, on the audited [stellar-contracts](https://github.com/OpenZeppelin/stellar-contracts) account | You need context rules, thresholds, or spending-limit policies |
+| [passkey-kit](https://github.com/stellar/passkey-kit) | A flat multi-signer `Signatures` map | The flat signer model covers your authorization needs |
+
+Both are maintained. Neither README declares the other deprecated.
+
 ### Resources
-- **GitHub**: https://github.com/kalepail/smart-account-kit
+- **GitHub**: https://github.com/stellar/smart-account-kit
 - **OpenZeppelin Contracts**: https://github.com/OpenZeppelin/stellar-contracts
-- **Legacy SDK**: https://github.com/kalepail/passkey-kit (for simpler use cases)
+- **Passkey Kit**: https://github.com/stellar/passkey-kit (sibling SDK — see above)

--- a/skills/standards/ecosystem.md
+++ b/skills/standards/ecosystem.md
@@ -173,9 +173,10 @@ SDK for integrating multiple Stellar wallets.
 
 ### Smart Account & Authentication
 
-#### Smart Account Kit (Recommended)
+#### Smart Account Kit
 Comprehensive TypeScript SDK for OpenZeppelin Smart Accounts on Stellar.
-- **GitHub**: https://github.com/kalepail/smart-account-kit
+- **GitHub**: https://github.com/stellar/smart-account-kit
+- **Authorization model**: OpenZeppelin context rules + an auth digest
 - **Use Case**: Production smart wallets with passkeys
 - **Built On**: [OpenZeppelin stellar-contracts](https://github.com/OpenZeppelin/stellar-contracts)
 - **Features**:
@@ -186,11 +187,11 @@ Comprehensive TypeScript SDK for OpenZeppelin Smart Accounts on Stellar.
   - Built-in indexer for contract discovery
   - Multiple signer types (passkeys, Ed25519, policies)
 
-#### Passkey Kit (Legacy)
-Original TypeScript SDK for passkey-based smart wallets.
-- **GitHub**: https://github.com/kalepail/passkey-kit
-- **Status**: Legacy - use Smart Account Kit for new projects
-- **Use Case**: Simple passkey wallet integration
+#### Passkey Kit
+TypeScript SDK for passkey-based smart wallets. Sibling to Smart Account Kit, with a different authorization model — the two are not drop-in compatible.
+- **GitHub**: https://github.com/stellar/passkey-kit
+- **Authorization model**: A flat multi-signer `Signatures` map
+- **Use Case**: Passkey wallet integration where the flat signer model is enough
 - **Integration**: OpenZeppelin Relayer (gasless tx), Mercury (indexing)
 - **Demo**: [passkey-kit-demo.pages.dev](https://passkey-kit-demo.pages.dev)
 - **Example**: [Super Peach](https://github.com/kalepail/superpeach)

--- a/skills/standards/resources.md
+++ b/skills/standards/resources.md
@@ -57,8 +57,8 @@ Curated documentation, SDK, tooling, and learning links. Companion to [SKILL.md]
 - [Contract Wizard](https://wizard.openzeppelin.com/stellar) - Generate contracts
 
 ### Smart Account SDKs
-- [Smart Account Kit](https://github.com/kalepail/smart-account-kit) - Production smart wallet SDK (recommended)
-- [Passkey Kit](https://github.com/kalepail/passkey-kit) - Legacy passkey wallet SDK
+- [Smart Account Kit](https://github.com/stellar/smart-account-kit) - Smart wallet SDK using OpenZeppelin context rules + auth digest
+- [Passkey Kit](https://github.com/stellar/passkey-kit) - Sibling smart wallet SDK using a flat multi-signer `Signatures` map
 - [Super Peach](https://github.com/kalepail/superpeach) - Smart wallet implementation example
 
 ### Developer Tools


### PR DESCRIPTION
🤖 _Automated message from Kaan's Automated Triage Bot._

Closes #108

Two problems in `skills/dapp/smart-accounts.md`, both confirmed.

**Stale links.** `kalepail/smart-account-kit` and `kalepail/passkey-kit` are both archived. The GitHub API returns `archived: true` and a description of `[MOVED → github.com/stellar/...]` for each. The links now point at `stellar/smart-account-kit` and `stellar/passkey-kit`, which are live and not archived.

**Unsupported label.** The file called passkey-kit a "Legacy SDK". No canonical README says that. The `stellar/passkey-kit` README describes the two kits as siblings with different on-chain authorization models that are "not drop-in compatible", and asks the reader to "pick the model that fits your app". A full-text scan for `legacy`, `precursor`, `greenfield`, `new project`, `deprecat`, and `supersede` found no kit-level legacy claim; the `legacy` hits are about signer generations, the 1-9 contract error range, and superseded tuple events. The `stellar/smart-account-kit` README never mentions passkey-kit at all.

So this drops the label and adds a short comparison table: context rules plus auth digest for smart-account-kit, a flat multi-signer `Signatures` map for passkey-kit. That is the boundary the README states.

**Scope note.** The issue names `smart-accounts.md`. The same two archived links and the same legacy label were also in `skills/standards/resources.md` and `skills/standards/ecosystem.md`, so I corrected them in the same pass rather than leave known-broken links behind. Happy to split that into its own PR if you prefer.

The change is markdown under `skills/` only. The site build does not read these files, so `lint`, `lint:ts`, and `build` are unaffected.
