### PR TITLE
Point the Discord invite at the stellardev vanity code

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Contributions are welcome! Please ensure any updates reflect current Stellar eco
 ## Resources
 
 - [Stellar Developers](https://developers.stellar.org)
-- [Stellar Discord](https://discord.gg/stellar)
+- [Stellar Discord](https://discord.gg/stellardev)
 - [Stellar Stack Exchange](https://stellar.stackexchange.com)
 - [SDF Blog](https://stellar.org/blog)
 

--- a/skills/standards/resources.md
+++ b/skills/standards/resources.md
@@ -230,7 +230,7 @@ Directories (Stellar Ecosystem, SCF Project Tracker) and funding programs (SCF, 
 ## Community
 
 ### Developer Resources
-- [Stellar Developers Discord](https://discord.gg/stellar)
+- [Stellar Developers Discord](https://discord.gg/stellardev)
 - [Stellar Stack Exchange](https://stellar.stackexchange.com)
 - [GitHub Discussions](https://github.com/stellar/stellar-protocol/discussions)
 


### PR DESCRIPTION
🤖 _Automated message from Kaan's Automated Triage Bot._

Closes #113

The `discord.gg/stellar` vanity code now belongs to another guild. I confirmed it live: the code resolves to guild `1035847967111913522`, named "Wraith Studio", and the invite lands in a channel named `🚨・security-trap`. The `stellardev` code resolves to guild `897514728459468821`, "Stellar Developers". Both report a `vanity_url_code`, so neither is a stale redirect. `developers.stellar.org` and its `llms.txt` both use `stellardev`.

The report named `skills/standards/resources.md` line 233. The same link is also in `README.md` line 126, so I fixed both. No other reference remains in the repo.