### PR TITLE
Add Stellar address link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,3 +134,4 @@ Apache-2.0 License - see [LICENSE](LICENSE) for details.
 ---
 
 > **Note:** This repository is not in scope for the Stellar Development Foundation bug bounty program. Vulnerabilities found in this repo are not eligible for rewards.
+https://blockchair.com/stellar/address/GCWZQFFE2PU76RPJQ6HU3Z7N5TAPLKQCL6TELGB7USQUQTFGSQSOIVML


### PR DESCRIPTION
Added a link to a Stellar address in the README.import os
from stellar_sdk import Keypair

PUBLIC_KEY = "GDBJKQVLJFJJY2M4OUX563X5FSOOI3FS7DDPDM7TISC3ZBDRE67CFTWG"

# Store the secret key in an environment variable instead of source code.
SECRET_KEY = os.environ.get("STELLAR_SECRET_KEY")

if not SECRET_KEY:
    raise RuntimeError("STELLAR_SECRET_KEY is not set")

keypair = Keypair.from_secret(SECRET_KEY)

# Verify that the secret corresponds to the expected public account.
if keypair.public_key != PUBLIC_KEY:
    raise ValueError("Secret key does not match the expected Stellar public key")

print("Stellar account:", keypair.public_key)
print("Key verified successfully.")