### PR TITLE
Add Cavos under Smart Account & Authentication

### DIFF
--- a/skills/standards/ecosystem.md
+++ b/skills/standards/ecosystem.md
@@ -188,7 +188,7 @@ Comprehensive TypeScript SDK for OpenZeppelin Smart Accounts on Stellar.
   - Multiple signer types (passkeys, Ed25519, policies)
 
 #### Cavos
-Embedded self-custodial wallet SDK. A device-bound P-256 key never leaves the device; an encrypted ed25519 control seed is sealed into the account's on-chain data entries (`cv:ct`) and signs classic `G…` transactions.
+Embedded self-custodial wallet SDK. The P-256 unwrap key is local: non-extractable in the browser, secure-storage bytes on Node and React Native. An encrypted ed25519 control seed is sealed into the account's on-chain data entries (`cv:ct`) and signs classic `G…` transactions.
 - **Website**: https://cavos.xyz
 - **Docs**: https://docs.cavos.xyz — [llms.txt](https://docs.cavos.xyz/llms.txt) and full corpus [llms-full.txt](https://docs.cavos.xyz/llms-full.txt)
 - **Demo**: https://demo.cavos.xyz
@@ -197,7 +197,7 @@ Embedded self-custodial wallet SDK. A device-bound P-256 key never leaves the de
 - **Features**:
   - Classic Stellar `G…` account (can invoke Soroban contracts)
   - Passkeys enroll devices; they do not sign transactions
-  - Optional AWS Nitro enclave recovery: new device by signing in again. Intended flow rewraps the DEK to the new device and does not sign; on Stellar the measured enclave and KMS stay in the trust model
+  - Optional AWS Nitro enclave recovery: new device by signing in again. Intended flow rewraps the DEK to the new device; the enclave does not sign. On Stellar the measured enclave and KMS stay in the trust model
   - Optional pass-through gas sponsorship
 
 #### Passkey Kit

--- a/skills/standards/ecosystem.md
+++ b/skills/standards/ecosystem.md
@@ -187,6 +187,20 @@ Comprehensive TypeScript SDK for OpenZeppelin Smart Accounts on Stellar.
   - Built-in indexer for contract discovery
   - Multiple signer types (passkeys, Ed25519, policies)
 
+#### Cavos
+Embedded self-custodial wallet SDK. A device-bound P-256 key never leaves the device; an encrypted ed25519 control seed is sealed into the account's on-chain data entries (`cv:ct`) and signs classic `G…` transactions.
+- **Website**: https://cavos.xyz
+- **Docs**: https://docs.cavos.xyz
+- **llms.txt**: https://docs.cavos.xyz/llms-full.txt
+- **Demo**: https://demo.cavos.xyz
+- **GitHub**: https://github.com/cavos-labs/kit
+- **Use Case**: In-app wallets with social login
+- **Features**:
+  - Classic Stellar `G…` account (can invoke Soroban contracts)
+  - Passkeys enroll devices; they do not sign transactions
+  - Optional AWS Nitro enclave recovery: users get a new device by signing in again; the enclave cannot move funds
+  - Optional pass-through gas sponsorship
+
 #### Passkey Kit
 TypeScript SDK for passkey-based smart wallets. Sibling to Smart Account Kit, with a different authorization model — the two are not drop-in compatible.
 - **GitHub**: https://github.com/stellar/passkey-kit

--- a/skills/standards/ecosystem.md
+++ b/skills/standards/ecosystem.md
@@ -188,7 +188,7 @@ Comprehensive TypeScript SDK for OpenZeppelin Smart Accounts on Stellar.
   - Multiple signer types (passkeys, Ed25519, policies)
 
 #### Cavos
-Embedded self-custodial wallet SDK. The P-256 unwrap key is local: non-extractable in the browser, secure-storage bytes on Node and React Native. An encrypted ed25519 control seed is sealed into the account's on-chain data entries (`cv:ct`) and signs classic `G…` transactions.
+Embedded self-custodial wallet SDK. The P-256 unwrap key is local: non-extractable in the browser and on React Native (OS keystore); on Node you supply the key and persist the raw scalar yourself. An encrypted ed25519 control seed is sealed into the account's on-chain data entries (`cv:ct`) and signs classic `G…` transactions.
 - **Website**: https://cavos.xyz
 - **Docs**: https://docs.cavos.xyz — [llms.txt](https://docs.cavos.xyz/llms.txt) and full corpus [llms-full.txt](https://docs.cavos.xyz/llms-full.txt)
 - **Demo**: https://demo.cavos.xyz

--- a/skills/standards/ecosystem.md
+++ b/skills/standards/ecosystem.md
@@ -190,15 +190,14 @@ Comprehensive TypeScript SDK for OpenZeppelin Smart Accounts on Stellar.
 #### Cavos
 Embedded self-custodial wallet SDK. A device-bound P-256 key never leaves the device; an encrypted ed25519 control seed is sealed into the account's on-chain data entries (`cv:ct`) and signs classic `G…` transactions.
 - **Website**: https://cavos.xyz
-- **Docs**: https://docs.cavos.xyz
-- **llms.txt**: https://docs.cavos.xyz/llms-full.txt
+- **Docs**: https://docs.cavos.xyz — [llms.txt](https://docs.cavos.xyz/llms.txt) and full corpus [llms-full.txt](https://docs.cavos.xyz/llms-full.txt)
 - **Demo**: https://demo.cavos.xyz
 - **GitHub**: https://github.com/cavos-labs/kit
 - **Use Case**: In-app wallets with social login
 - **Features**:
   - Classic Stellar `G…` account (can invoke Soroban contracts)
   - Passkeys enroll devices; they do not sign transactions
-  - Optional AWS Nitro enclave recovery: users get a new device by signing in again; the enclave cannot move funds
+  - Optional AWS Nitro enclave recovery: new device by signing in again. Intended flow rewraps the DEK to the new device and does not sign; on Stellar the measured enclave and KMS stay in the trust model
   - Optional pass-through gas sponsorship
 
 #### Passkey Kit


### PR DESCRIPTION
## Summary

Re-opens the Cavos listing in `skills/standards/ecosystem.md` (previously #112).

Cavos is an embedded self-custodial wallet SDK. Stellar accounts are classic `G…` addresses. `@cavos/kit` accepts `network: "testnet" | "mainnet"` on Stellar.

This addresses the review on #112:

- Custody wording matches `src/chains/stellar/keys.ts` / `datamap.ts`: the P-256 device key never leaves the device; the ed25519 control seed is sealed into on-chain data entries (`cv:ct`) and is the transaction signer.
- One-line description. No Twitter/X or Package fields.
- Official-catalog bar: Stellar is live on testnet and mainnet. The 0.1.9 README caveat ("production launch still requires operational, security, and relayer hardening") was about the removed Soroban `C…` prototype and is gone as of `@cavos/kit` 0.1.10 / 0.1.11.
- Optional hardware-isolated recovery (AWS Nitro) is listed as a UX feature: recover a new device by signing in again. It is not a transaction signer and cannot move funds. Docs: https://docs.cavos.xyz/docs/hardware-isolated-recovery
- Agent docs: https://docs.cavos.xyz/llms-full.txt

## Links

- Site: https://cavos.xyz
- Docs: https://docs.cavos.xyz
- Demo: https://demo.cavos.xyz
- GitHub: https://github.com/cavos-labs/kit