### PR TITLE
Sort community skills alphabetically

### DIFF
--- a/site/CLAUDE.md
+++ b/site/CLAUDE.md
@@ -90,7 +90,9 @@ then append to `SKILL_CARD_SOURCES`:
 
 **Ecosystem:** external link, no upstream copy. New entries are picked
 up automatically by the community search, pagination, and llms.txt; no
-other wiring needed.
+other wiring needed. Insert the entry alphabetically by `title`
+(case-insensitive) in `ECOSYSTEM_CARDS`, not appended at the end, so a
+card's position reflects its name rather than merge order.
 
 ```ts
 {

--- a/site/README.md
+++ b/site/README.md
@@ -145,7 +145,9 @@ page. There's no upstream copy — the card just links out to the
 external SKILL.md, and the user copies that URL to install it with
 their agent.
 
-Append to `ECOSYSTEM_CARDS` in `src/data/skills.ts`:
+Insert the entry alphabetically by `title` (case-insensitive) in
+`ECOSYSTEM_CARDS` in `src/data/skills.ts`, not appended at the end, so a
+card's position reflects its name rather than merge order:
 
 ```ts
 {

--- a/site/src/data/skills.ts
+++ b/site/src/data/skills.ts
@@ -144,37 +144,6 @@ export const SKILL_CARD_SOURCES: readonly SkillCardSource[] = [
  */
 export const ECOSYSTEM_CARDS: readonly EcosystemCardSource[] = [
   {
-    title: "OpenZeppelin Contracts",
-    description:
-      "Scaffold a Stellar smart contract project with OpenZeppelin's audited Stellar contract libraries. Walks through Rust toolchain setup, Stellar CLI install, workspace dependencies, and applying the pausable and ownable macros to your contract.",
-    pathLabel: "OpenZeppelin/openzeppelin-skills",
-    copyValue:
-      "https://raw.githubusercontent.com/OpenZeppelin/openzeppelin-skills/main/skills/setup-stellar-contracts/SKILL.md",
-  },
-  {
-    title: "DeFindex SDK",
-    description:
-      "Integrate DeFindex vaults on Stellar with the @defindex/sdk TypeScript package. Covers vault deposits and withdrawals, balance and APY queries, programmatic vault creation, and the unsigned-XDR signing pattern for backend and bot integrations.",
-    pathLabel: "paltalabs/defindex-sdk",
-    copyValue:
-      "https://raw.githubusercontent.com/paltalabs/defindex-sdk/main/defindex-sdk-skill.md",
-  },
-  {
-    title: "Soroswap SDK",
-    description:
-      "Trade on Soroswap DEX from a backend, bot, or swap widget using the @soroswap/sdk TypeScript package. Covers token swaps, liquidity pool operations, price and route queries, API key handling, and signing flows for both server keypairs and browser wallets.",
-    pathLabel: "soroswap/sdk",
-    copyValue: "https://raw.githubusercontent.com/soroswap/sdk/main/soroswap-sdk-skill.md",
-  },
-  {
-    title: "Trustless Work Escrow",
-    description:
-      "Build escrow and milestone-based payment workflows on Stellar with the Trustless Work platform. Covers single-release and multi-release escrows, trustline configuration, dispute handling, and three integration paths: REST API, React SDK hooks, and pre-built Blocks UI components.",
-    pathLabel: "Trustless-Work/trustless-work-dev-skill",
-    copyValue:
-      "https://raw.githubusercontent.com/Trustless-Work/trustless-work-dev-skill/main/SKILL.md",
-  },
-  {
     title: "Agent Browser WebAuthn",
     description:
       "Drive passkey and Stellar smart account browser tests with agent-browser and Chrome DevTools virtual WebAuthn authenticators.",
@@ -191,21 +160,6 @@ export const ECOSYSTEM_CARDS: readonly EcosystemCardSource[] = [
       "https://raw.githubusercontent.com/CheesecakeLabs/stellar-anchor-skill/main/SKILL.md",
   },
   {
-    title: "Eunomia Bounded Agent Treasury",
-    description:
-      "Give an AI agent a non-custodial, contract-bounded spending account on Stellar with Eunomia (formerly PRISM). Covers treasury deployment with per-payment and rolling daily limits, payee whitelists, time-bound agent session keys, escrow, x402-gated payments, and Groth16/BN254 ZK compliance proofs verified on-chain.",
-    pathLabel: "eunomia-finance/eunomia",
-    copyValue: "https://raw.githubusercontent.com/eunomia-finance/eunomia/main/SKILL.md",
-  },
-  {
-    title: "ROZO Intents",
-    description:
-      "Send USDC and USDT across Stellar, Ethereum, Arbitrum, Base, BSC, Polygon, and Solana using natural language. Covers cross-chain bridging, wallet detection, fee estimation, tiered confirmation logic, and QR code payment parsing inside Claude Code.",
-    pathLabel: "RozoAI/rozo-intents-skills",
-    copyValue:
-      "https://raw.githubusercontent.com/RozoAI/rozo-intents-skills/main/SKILL.md",
-  },
-  {
     title: "Caatinga",
     description:
       "Deploy and manage Soroban contract lifecycles with the Caatinga CLI (ctg). Covers the init → doctor → build → deploy → generate → invoke workflow, the multi-contract Deployment Graph, versioned caatinga.artifacts.json as the source of truth for contract IDs, generated TypeScript bindings, and wallet adapters (Freighter, Stellar Wallets Kit) — with hard rules against raw secret keys on the command line and hand-edited artifacts or bindings.",
@@ -214,12 +168,35 @@ export const ECOSYSTEM_CARDS: readonly EcosystemCardSource[] = [
       "https://raw.githubusercontent.com/Dione-b/caatinga-skill/master/skills/caatinga/SKILL.md",
   },
   {
-    title: "Sozu Testnet USDC Faucet",
+    title: "Cogladius",
     description:
-      "Claim Circle USDC on Stellar testnet with a PoW-gated CLI, using an existing C…/G… address or a newly generated G… wallet with a USDC trustline.",
-    pathLabel: "blessedux/agent-skills",
+      "Register an AI agent to earn XLM by completing on-chain tasks: one-call permissionless registration, task polling, solution submission, and payout from a non-custodial Soroban escrow on an ed25519-verified judge verdict.",
+    pathLabel: "furkanyesildag/cogladius",
     copyValue:
-      "https://raw.githubusercontent.com/blessedux/agent-skills/main/sozu-faucet/SKILL.md",
+      "https://raw.githubusercontent.com/furkanyesildag/cogladius/main/SKILL.md",
+  },
+  {
+    title: "Contextio SDK",
+    description:
+      "Integrate contextio-sdk: verifiable, non-custodial legal context binding (Legal Context Protocol / LCP) for Stellar treasury and payroll. Covers Sign In With Stellar (SEP-53) wallet auth, reading a tenant's treasury/payroll/agent state, triggering an agent proposal, and independently hashing/verifying an LCP document against an on-chain hash.",
+    pathLabel: "Eras256/Contextio",
+    copyValue:
+      "https://raw.githubusercontent.com/Eras256/Contextio/main/packages/sdk/SKILL.md",
+  },
+  {
+    title: "DeFindex SDK",
+    description:
+      "Integrate DeFindex vaults on Stellar with the @defindex/sdk TypeScript package. Covers vault deposits and withdrawals, balance and APY queries, programmatic vault creation, and the unsigned-XDR signing pattern for backend and bot integrations.",
+    pathLabel: "paltalabs/defindex-sdk",
+    copyValue:
+      "https://raw.githubusercontent.com/paltalabs/defindex-sdk/main/defindex-sdk-skill.md",
+  },
+  {
+    title: "Eunomia Bounded Agent Treasury",
+    description:
+      "Give an AI agent a non-custodial, contract-bounded spending account on Stellar with Eunomia (formerly PRISM). Covers treasury deployment with per-payment and rolling daily limits, payee whitelists, time-bound agent session keys, escrow, x402-gated payments, and Groth16/BN254 ZK compliance proofs verified on-chain.",
+    pathLabel: "eunomia-finance/eunomia",
+    copyValue: "https://raw.githubusercontent.com/eunomia-finance/eunomia/main/SKILL.md",
   },
   {
     title: "LumenLoop MCP Connect",
@@ -230,12 +207,90 @@ export const ECOSYSTEM_CARDS: readonly EcosystemCardSource[] = [
       "https://raw.githubusercontent.com/lumenloop/lumenloop-skills/main/skills/lumenloop-mcp-connect/SKILL.md",
   },
   {
+    title: "MPP Discover",
+    description:
+      "Find and pay APIs from 90+ services with Stellar USDC through MPP Router — including OpenAI, Anthropic, DeepSeek, Perplexity, Exa, Firecrawl, and Tavily. An agent fetches the live service catalog, picks a service, and settles per request. Every verified service is backed by a real paid call with a published Stellar transaction hash.",
+    pathLabel: "mpprouter/stellar-agent-wallet-skill",
+    copyValue:
+      "https://raw.githubusercontent.com/mpprouter/stellar-agent-wallet-skill/main/skills/discover/SKILL.md",
+  },
+  {
+    title: "Nirium Agentic Payments",
+    description:
+      "Charge AI agents per API call on Stellar with the Nirium toolkit: scaffold a working x402 seller with nirium-cli in one command, charge per route with x402Serve() from the nirium SDK, and read live protocol data, market state, autonomous loop status, and execution nodes through the nirium-mcp server. Live on mainnet since July 9, 2026.",
+    pathLabel: "nirium-protocol/nirium-sdk",
+    copyValue:
+      "https://raw.githubusercontent.com/nirium-protocol/nirium-sdk/main/skills/nirium-agentic-payments/SKILL.md",
+  },
+  {
+    title: "OpenZeppelin Contracts",
+    description:
+      "Scaffold a Stellar smart contract project with OpenZeppelin's audited Stellar contract libraries. Walks through Rust toolchain setup, Stellar CLI install, workspace dependencies, and applying the pausable and ownable macros to your contract.",
+    pathLabel: "OpenZeppelin/openzeppelin-skills",
+    copyValue:
+      "https://raw.githubusercontent.com/OpenZeppelin/openzeppelin-skills/main/skills/setup-stellar-contracts/SKILL.md",
+  },
+  {
+    title: "PMLL",
+    description:
+      "Gives AI agents persistent spatial memory so they can retain long-term context, form symbiotic memory layers, and maintain durable state across sessions; supports PPM-based context stitching, Context+ pipelines, and supermodeltools/cli for graphing and analysis. On-chain commitment anchoring on Stellar (32-byte hashes via a Soroban contract) is planned.",
+    pathLabel: "drQedwards/pmll",
+    copyValue: "https://raw.githubusercontent.com/drQedwards/pmll/main/SKILL.md",
+  },
+  {
+    title: "ROZO Checkout",
+    description:
+      "Pay for AI services with Stellar USDC — e.g. OpenRouter and Venice.ai, which cannot take Stellar directly — through a one-time deposit order and automatic invoice settlement. More AI services coming.",
+    pathLabel: "RozoAI/rozo-checkout-skill",
+    copyValue:
+      "https://raw.githubusercontent.com/RozoAI/rozo-checkout-skill/main/SKILL.md",
+  },
+  {
+    title: "ROZO Intents",
+    description:
+      "Send USDC and USDT across Stellar, Ethereum, Arbitrum, Base, BSC, Polygon, and Solana using natural language. Covers cross-chain bridging, wallet detection, fee estimation, tiered confirmation logic, and QR code payment parsing inside Claude Code.",
+    pathLabel: "RozoAI/rozo-intents-skills",
+    copyValue:
+      "https://raw.githubusercontent.com/RozoAI/rozo-intents-skills/main/SKILL.md",
+  },
+  {
     title: "SCF Submission Radar",
     description:
       "Position a Stellar Community Fund idea against prior submissions before applying: find similar past proposals, check what's been funded in an area, and sharpen positioning.",
     pathLabel: "lumenloop/lumenloop-skills",
     copyValue:
       "https://raw.githubusercontent.com/lumenloop/lumenloop-skills/main/skills/scf-submission-radar/SKILL.md",
+  },
+  {
+    title: "Soroban Common Mistakes",
+    description:
+      "Review Soroban contracts against 23 recurring security mistakes before shipping: missing authorization, storage and TTL pitfalls, arithmetic overflow, and unsafe panic handling. Ships with a reviewable checklist, a PR template, and a Scout CI workflow. Available in English and Spanish.",
+    pathLabel: "mariaelisaaraya/stellar-security-guide",
+    copyValue:
+      "https://raw.githubusercontent.com/mariaelisaaraya/stellar-security-guide/main/skills/soroban-common-mistakes/SKILL.md",
+  },
+  {
+    title: "Soroswap SDK",
+    description:
+      "Trade on Soroswap DEX from a backend, bot, or swap widget using the @soroswap/sdk TypeScript package. Covers token swaps, liquidity pool operations, price and route queries, API key handling, and signing flows for both server keypairs and browser wallets.",
+    pathLabel: "soroswap/sdk",
+    copyValue: "https://raw.githubusercontent.com/soroswap/sdk/main/soroswap-sdk-skill.md",
+  },
+  {
+    title: "Sozu Testnet USDC Faucet",
+    description:
+      "Claim Circle USDC on Stellar testnet with a PoW-gated CLI, using an existing C…/G… address or a newly generated G… wallet with a USDC trustline.",
+    pathLabel: "blessedux/agent-skills",
+    copyValue:
+      "https://raw.githubusercontent.com/blessedux/agent-skills/main/sozu-faucet/SKILL.md",
+  },
+  {
+    title: "Stellar Agent Search",
+    description:
+      "Read-only, keyless MCP server that lets an AI agent discover, rank, and vet on-chain Stellar 8004 agents on mainnet by natural-language query, stopping before any payment or signing.",
+    pathLabel: "berkingurcan/stellar-agent-search",
+    copyValue:
+      "https://raw.githubusercontent.com/berkingurcan/stellar-agent-search/main/skills/mcp/SKILL.md",
   },
   {
     title: "Stellar Builder Quickstart",
@@ -293,6 +348,13 @@ export const ECOSYSTEM_CARDS: readonly EcosystemCardSource[] = [
     copyValue: "https://stellarlight.xyz/skills/stellar-scout.md",
   },
   {
+    title: "StellarTools",
+    description:
+      "Stripe-level payment infrastructure for Stellar. Accept crypto and fiat payments with hosted checkouts, Soroban-powered subscriptions with flexible billing periods, customer portals, and normalized webhooks. Includes WooCommerce and Shopify adapters, an apps marketplace, and an MCP server for agent-driven payment management.",
+    pathLabel: "payrouteshq/stellartools",
+    copyValue: "https://raw.githubusercontent.com/payrouteshq/stellartools/main/SKILL.md",
+  },
+  {
     title: "Sub Rosa",
     description:
       "Integrate sealed coordination into Stellar apps with @sub-rosa/sdk: run sealed-bid asset auctions with SAC escrow and atomic lot settlement, confidential proposal rounds, Drand-timed reveal, permissionless lifecycle automation, and verifiable Core v2 receipts.",
@@ -301,73 +363,11 @@ export const ECOSYSTEM_CARDS: readonly EcosystemCardSource[] = [
       "https://raw.githubusercontent.com/karagozemin/Sub-Rosa/main/skills/sub-rosa/SKILL.md",
   },
   {
-    title: "ROZO Checkout",
+    title: "Trustless Work Escrow",
     description:
-      "Pay for AI services with Stellar USDC — e.g. OpenRouter and Venice.ai, which cannot take Stellar directly — through a one-time deposit order and automatic invoice settlement. More AI services coming.",
-    pathLabel: "RozoAI/rozo-checkout-skill",
+      "Build escrow and milestone-based payment workflows on Stellar with the Trustless Work platform. Covers single-release and multi-release escrows, trustline configuration, dispute handling, and three integration paths: REST API, React SDK hooks, and pre-built Blocks UI components.",
+    pathLabel: "Trustless-Work/trustless-work-dev-skill",
     copyValue:
-      "https://raw.githubusercontent.com/RozoAI/rozo-checkout-skill/main/SKILL.md",
-  },
-  {
-    title: "MPP Discover",
-    description:
-      "Find and pay APIs from 90+ services with Stellar USDC through MPP Router — including OpenAI, Anthropic, DeepSeek, Perplexity, Exa, Firecrawl, and Tavily. An agent fetches the live service catalog, picks a service, and settles per request. Every verified service is backed by a real paid call with a published Stellar transaction hash.",
-    pathLabel: "mpprouter/stellar-agent-wallet-skill",
-    copyValue:
-      "https://raw.githubusercontent.com/mpprouter/stellar-agent-wallet-skill/main/skills/discover/SKILL.md",
-  },
-  {
-    title: "Stellar Agent Search",
-    description:
-      "Read-only, keyless MCP server that lets an AI agent discover, rank, and vet on-chain Stellar 8004 agents on mainnet by natural-language query, stopping before any payment or signing.",
-    pathLabel: "berkingurcan/stellar-agent-search",
-    copyValue:
-      "https://raw.githubusercontent.com/berkingurcan/stellar-agent-search/main/skills/mcp/SKILL.md",
-  },
-  {
-    title: "Cogladius",
-    description:
-      "Register an AI agent to earn XLM by completing on-chain tasks: one-call permissionless registration, task polling, solution submission, and payout from a non-custodial Soroban escrow on an ed25519-verified judge verdict.",
-    pathLabel: "furkanyesildag/cogladius",
-    copyValue:
-      "https://raw.githubusercontent.com/furkanyesildag/cogladius/main/SKILL.md",
-  },
-  {
-    title: "Soroban Common Mistakes",
-    description:
-      "Review Soroban contracts against 23 recurring security mistakes before shipping: missing authorization, storage and TTL pitfalls, arithmetic overflow, and unsafe panic handling. Ships with a reviewable checklist, a PR template, and a Scout CI workflow. Available in English and Spanish.",
-    pathLabel: "mariaelisaaraya/stellar-security-guide",
-    copyValue:
-      "https://raw.githubusercontent.com/mariaelisaaraya/stellar-security-guide/main/skills/soroban-common-mistakes/SKILL.md",
-  },
-  {
-    title: "StellarTools",
-    description:
-      "Stripe-level payment infrastructure for Stellar. Accept crypto and fiat payments with hosted checkouts, Soroban-powered subscriptions with flexible billing periods, customer portals, and normalized webhooks. Includes WooCommerce and Shopify adapters, an apps marketplace, and an MCP server for agent-driven payment management. ⁠",
-    pathLabel: "payrouteshq/stellartools",
-    copyValue: "https://raw.githubusercontent.com/payrouteshq/stellartools/main/SKILL.md",
-  },
-  {
-    title: "Nirium Agentic Payments",
-    description:
-      "Charge AI agents per API call on Stellar with the Nirium toolkit: scaffold a working x402 seller with nirium-cli in one command, charge per route with x402Serve() from the nirium SDK, and read live protocol data, market state, autonomous loop status, and execution nodes through the nirium-mcp server. Live on mainnet since July 9, 2026.",
-    pathLabel: "nirium-protocol/nirium-sdk",
-    copyValue:
-      "https://raw.githubusercontent.com/nirium-protocol/nirium-sdk/main/skills/nirium-agentic-payments/SKILL.md",
-  },
-  {
-    title: "Contextio SDK",
-    description:
-      "Integrate contextio-sdk: verifiable, non-custodial legal context binding (Legal Context Protocol / LCP) for Stellar treasury and payroll. Covers Sign In With Stellar (SEP-53) wallet auth, reading a tenant's treasury/payroll/agent state, triggering an agent proposal, and independently hashing/verifying an LCP document against an on-chain hash.",
-    pathLabel: "Eras256/Contextio",
-    copyValue:
-      "https://raw.githubusercontent.com/Eras256/Contextio/main/packages/sdk/SKILL.md",
-  },
-  {
-    title: "PMLL",
-    description:
-      "Gives AI agents persistent spatial memory so they can retain long-term context, form symbiotic memory layers, and maintain durable state across sessions; supports PPM-based context stitching, Context+ pipelines, and supermodeltools/cli for graphing and analysis. On-chain commitment anchoring on Stellar (32-byte hashes via a Soroban contract) is planned.",
-    pathLabel: "drQedwards/pmll",
-    copyValue: "https://raw.githubusercontent.com/drQedwards/pmll/main/SKILL.md",
+      "https://raw.githubusercontent.com/Trustless-Work/trustless-work-dev-skill/main/SKILL.md",
   },
 ] as const;


### PR DESCRIPTION
## Why this PR

Follow-up to https://github.com/stellar/stellar-dev-skill/pull/111 implementing @kaankacar's request in https://github.com/stellar/stellar-dev-skill/pull/111#issuecomment-5455922718.

#111 conflicts with `main` after #103 (`copyValue` blob URLs → `raw.githubusercontent.com`). Kan asked to **rebase on main and apply the sort there**, not resolve the conflict line by line (that would restore blob URLs). I cannot push to @mariaelisaaraya's fork, so this is the same change on current `main`.

## What

- Sort all 29 `ECOSYSTEM_CARDS` by `title` (case-insensitive). Same permutation as #111.
- Keep every `copyValue` as `raw.githubusercontent.com` (28 raw URLs, zero `/blob/`).
- Strip the two invisible characters from the StellarTools description (same cleanup as #111).
- `site/README.md`: stop saying "Append to `ECOSYSTEM_CARDS`"; insert alphabetically by title (matches `site/CLAUDE.md`).
- `site/CLAUDE.md`: same insertion rule as in #111.

No CI drift check here — Kan said that can be its own PR.

## Test plan

- [x] 29 cards, titles sorted case-insensitive
- [x] no `github.com/.../blob/` in `ECOSYSTEM_CARDS`
- [ ] `pnpm check:ecosystem-links` / `pnpm lint` / `pnpm lint:ts` / `pnpm build` on `site-ci` after this push