### PR TITLE
Add Pollar Wallets & Fiat Ramps to ECOSYSTEM_CARDS

### DIFF
--- a/site/src/data/skills.ts
+++ b/site/src/data/skills.ts
@@ -370,4 +370,12 @@ export const ECOSYSTEM_CARDS: readonly EcosystemCardSource[] = [
     pathLabel: "drQedwards/pmll",
     copyValue: "https://raw.githubusercontent.com/drQedwards/pmll/main/SKILL.md",
   },
+  {
+    title: "Pollar Wallets & Fiat Ramps",
+    description:
+      "Add embedded Stellar wallets and local fiat on/off-ramps to a web or React Native app with @pollar/core and @pollar/react. Users sign in with email, social or a passkey and get a funded account with no seed phrase. Covers ramp quotes and country availability, the custodial and external signing paths, payments, sponsored (gasless) activation and trustlines, multi-venue swaps, and SEP-53 / SEP-10 ownership proofs.",
+    pathLabel: "pollar-xyz/pollar",
+    copyValue:
+      "https://raw.githubusercontent.com/pollar-xyz/pollar/main/skills/pollar-wallet-auth/SKILL.md",
+  },
 ] as const;


### PR DESCRIPTION
Adds an ecosystem entry for the Pollar skill.

Pollar is wallet-as-a-service for Stellar with local fiat on/off-ramps built in. A user signs in with Google, GitHub, email OTP or a device passkey and ends up holding a funded Stellar account with trustlines already set, without ever seeing a secret key. The same client quotes and runs fiat deposits and withdrawals over local rails (SPEI, Pix, PSE, ACH, ...), and connects external wallets (Freighter, Albedo, xBull) so both kinds of user go through one code path.

The skill is a router: `SKILL.md` covers setup, the auth state machine and the three custody types (custodial G-address, passkey C-address, external), and dispatches to `ramps.md`, `react.md`, `react-native.md` and `transactions.md` for the ramp flow, framework wiring and the rest of the transaction surface.

- Skill: https://github.com/pollar-xyz/pollar/tree/main/skills/pollar-wallet-auth
- Docs: https://docs.pollar.xyz

`copyValue` points at `raw.githubusercontent.com`; `check:ecosystem-links` passes locally (30 entries, no blob URLs).
