### PR TITLE
fix(smart-contracts): mainnet is on protocol 27, and the SDK has stable 27 releases

### DIFF
--- a/skills/smart-contracts/SKILL.md
+++ b/skills/smart-contracts/SKILL.md
@@ -67,12 +67,13 @@ rustup target add wasm32v1-none     # once per toolchain
 crate-type = ["lib", "cdylib"]   # lib is needed for tests and fuzzing
 
 [dependencies]
-soroban-sdk = "27.0.0-rc.1"  # protocol 27; pre-releases need the exact version string.
-                             # Mainnet is on protocol 26 at the time of writing — use "26" there
-                             # until the network upgrades. Check crates.io for the latest.
+soroban-sdk = "27"  # protocol 27, which mainnet runs at the time of writing.
+                    # Pre-releases (`-rc.x`) exist only during a rollout and need the
+                    # exact version string. Check crates.io for the latest release, and
+                    # the live protocol version of your target network, before deploying.
 
 [dev-dependencies]
-soroban-sdk = { version = "27.0.0-rc.1", features = ["testutils"] }  # match above
+soroban-sdk = { version = "27", features = ["testutils"] }  # match above
 
 [profile.release]
 opt-level = "z"


### PR DESCRIPTION
🤖 _Automated message from Kaan's Automated Triage Bot._

Closes #124

The `Cargo.toml` example pinned `27.0.0-rc.1` and said mainnet was still on protocol 26. Two facts moved since then. Horizon's mainnet root reports `current_protocol_version: 27` today. crates.io has `soroban-sdk` 27.0.6, so protocol 27 no longer needs a pre-release pin.

The example now requires `"27"`, which is exactly what the `stellar contract init` workspace template writes. The pre-release rule stays in the comment as guidance, together with the reminder to check crates.io and the live protocol version before a deploy.

Verified: `cargo build --target wasm32v1-none --release` on a scratch crate with the skill's own counter contract and `soroban-sdk = "27"` (resolves to 27.0.6). No `evals/` scenario pins an SDK version, so none needed an update.
