### PR TITLE
docs(agentic-payments): name MPP's payment-method-agnostic scope

### DIFF
--- a/skills/agentic-payments/mpp.md
+++ b/skills/agentic-payments/mpp.md
@@ -1,5 +1,7 @@
 # MPP — Machine Payments Protocol (Charge + Session)
 
+MPP is a payment-method-agnostic HTTP 402 protocol, not a Stellar-only one: the core protocol standardizes the 402 Challenge/Credential exchange, and each **payment method** defines how one network settles it ([protocol spec](https://mpp.dev/protocol)). Tempo, Stripe and EVM are other payment methods; this guide documents the [Stellar payment method](https://mpp.dev/payment-methods/stellar). The packages split the same way: `mppx` is the general MPP framework, and `@stellar/mpp` is the Stellar payment method that extends it.
+
 Facilitator-free machine payments settled directly on Stellar: per-request Charge mode and channel-backed Session mode. Companion to [SKILL.md](SKILL.md) (decision table, shared testnet setup, USDC addresses); the facilitator-based alternative lives in [x402.md](x402.md).
 
 ## When to use MPP


### PR DESCRIPTION
🤖 _Automated message from Kaan's Automated Triage Bot._

Closes #125

The MPP guide started with Stellar settlement and never stated MPP's scope. A reader could conclude MPP is a Stellar protocol. This adds one paragraph at the top of `mpp.md`:

- MPP is a payment-method-agnostic HTTP 402 protocol. Each payment method settles on one network.
- This guide documents the Stellar payment method. Tempo, Stripe and EVM are other methods.
- `mppx` is the general MPP framework. `@stellar/mpp` is the Stellar payment method that extends it.

Verified against primary sources. mpp.dev/protocol has a "Payment method agnostic" section and says MPP "works with any payment network". mpp.dev/payment-methods/stellar calls Stellar a payment method and says `@stellar/mpp` extends `mppx`. The Stellar docs MPP page lists `mppx` as the "Core MPP framework library". npm describes `@stellar/mpp@0.7.1` as the "Stellar blockchain payment method for the Machine Payments Protocol (MPP)".

The rest of the guide stays unchanged, per the finding's recommendation. The change is markdown prose only, so it changes no site build input.
